### PR TITLE
Added client/server functionality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
         version='0.1',
         author='Viper Team',
         author_email='viper@inf.ethz.ch',
+        license='MPL-2.0',
         packages=['nagini_translation',],
         package_dir={'': 'src'},
         requires=[
@@ -35,10 +36,9 @@ setup(
             'Development Status :: 3 - Alpha',
             'Environment :: Console',
             'Intended Audience :: Developers',
-            # TODO: License? 
+            'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
             'Operating System :: OS Independent',
             'Programming Language :: Python :: 3 :: Only',
             'Topic :: Software Development',
             ],
-        #TODO: license=
         )

--- a/src/nagini_translation/client.py
+++ b/src/nagini_translation/client.py
@@ -1,13 +1,13 @@
 import argparse
 import zmq
 
+from nagini_translation.lib.constants import DEFAULT_CLIENT_SOCKET
 
-DEFAULT_SOCKET = "tcp://localhost:5555"
 
 context = zmq.Context()
 
 socket = context.socket(zmq.REQ)
-socket.connect(DEFAULT_SOCKET)
+socket.connect(DEFAULT_CLIENT_SOCKET)
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/src/nagini_translation/lib/constants.py
+++ b/src/nagini_translation/lib/constants.py
@@ -1,5 +1,9 @@
 import ast
 
+DEFAULT_CLIENT_SOCKET = "tcp://localhost:5555"
+DEFAULT_SERVER_SOCKET = "tcp://*:5555"
+
+
 LITERALS = ['True', 'False', 'None']
 
 BUILTINS = ['cast',

--- a/src/nagini_translation/main.py
+++ b/src/nagini_translation/main.py
@@ -14,6 +14,7 @@ import nagini_translation.mypy_patches.optional_patch
 from jpype import JavaException
 from nagini_translation.analyzer import Analyzer
 from nagini_translation.lib import config
+from nagini_translation.lib.constants import DEFAULT_SERVER_SOCKET
 from nagini_translation.lib.errors import error_manager
 from nagini_translation.lib.jvmaccess import JVM
 from nagini_translation.lib.typeinfo import TypeException, TypeInfo
@@ -33,7 +34,6 @@ from typing import Set
 
 TYPE_ERROR_PATTERN = r"^(?P<file>.*):(?P<line>\d+): error: (?P<msg>.*)$"
 TYPE_ERROR_MATCHER = re.compile(TYPE_ERROR_PATTERN)
-DEFAULT_SOCKET = "tcp://*:5555"
 
 
 def parse_sil_file(sil_path: str, jvm):
@@ -249,10 +249,8 @@ def main() -> None:
     if args.server:
         import zmq
         context = zmq.Context()
-
         socket = context.socket(zmq.REP)
-        socket.bind(DEFAULT_SOCKET)
-
+        socket.bind(DEFAULT_SERVER_SOCKET)
         load_sil_files(jvm, args.sif)
 
         while True:


### PR DESCRIPTION
Added a server option (which starts a long-running process with a long-running JVM and immediately performs some setup tasks that will be needed for verifying any program) and a corresponding client script, to be used mainly in combination with IDE integration; works with the Nagini PyCharm plugin (not currently working with VSCode).

We've had at least two versions of something like this before, but I cannot find the branch any more, so I just did it again and will make it part of the main branch this time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/84)
<!-- Reviewable:end -->
