### PR TITLE
Support for lock invariants

### DIFF
--- a/src/nagini_contracts/lock.py
+++ b/src/nagini_contracts/lock.py
@@ -35,7 +35,8 @@ class Lock(BaseLock, Generic[T]):
                  above: Optional[BaseLock]=None,
                  below: Optional[BaseLock]=None) -> None:
         """
-        Create a lock at the specified level, which protects ``locked_object``.
+        Create a lock whose level is below that of ``below`` and above that of ``above``,
+        which protects ``locked_object``.
         Creating the lock "shares" the object (i.e., exhales the invariant).
         Create subclasses of this class and override ``invariant`` to create a lock
         with an invariant.

--- a/src/nagini_translation/lib/program_nodes.py
+++ b/src/nagini_translation/lib/program_nodes.py
@@ -746,6 +746,9 @@ class GenericType(PythonType):
     def get_contents(self, only_top: bool) -> Dict:
         return self.python_class.get_contents(only_top)
 
+    def __hash__(self) -> int:
+        return hash(self.python_class)
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, GenericType):
             return False

--- a/src/nagini_translation/lib/program_nodes.py
+++ b/src/nagini_translation/lib/program_nodes.py
@@ -792,7 +792,7 @@ class UnionType(GenericType):
 
     @property
     def python_class(self) -> PythonClass:
-        return self.cls
+        return self.cls.python_class
 
     def get_types(self) -> Set[PythonClass]:
         """

--- a/src/nagini_translation/lib/resolver.py
+++ b/src/nagini_translation/lib/resolver.py
@@ -197,6 +197,12 @@ def _do_get_type(node: ast.AST, containers: List[ContainerInterface],
                     rectype = get_type(node.func.value, containers, container)
                     if target.generic_type != -1:
                         return rectype.type_args[target.generic_type]
+                    if isinstance(target.type, TypeVar):
+                        while rectype.python_class is not target.cls:
+                            rectype = rectype.superclass
+                        name_list = list(rectype.python_class.type_vars.keys())
+                        index = name_list.index(target.type.name)
+                        return rectype.type_args[index]
             return target.type
         if isinstance(target, PythonField):
             result = target.type
@@ -364,7 +370,8 @@ def _get_call_type(node: ast.Call, module: PythonModule,
                 assert ctx
                 assert ctx.current_contract_exception is not None
                 return ctx.current_contract_exception
-            elif node.func.id in ('Acc', 'Implies', 'Forall', 'Exists'):
+            elif node.func.id in ('Acc', 'Implies', 'Forall', 'Exists', 'MayCreate',
+                                  'MaySet'):
                 return module.global_module.classes[BOOL_TYPE]
             elif node.func.id == 'Old':
                 return get_type(node.args[0], containers, container)

--- a/src/nagini_translation/translators/method.py
+++ b/src/nagini_translation/translators/method.py
@@ -243,6 +243,7 @@ class MethodTranslator(CommonTranslator):
         """
         old_function = ctx.current_function
         ctx.current_function = func
+        self.bind_type_vars(func, ctx)
         pos = self.to_position(func.node, ctx)
         if not func.type:
             raise InvalidProgramException(func.node, 'function.type.none')

--- a/src/nagini_translation/translators/program.py
+++ b/src/nagini_translation/translators/program.py
@@ -818,7 +818,8 @@ class ProgramTranslator(CommonTranslator):
                     if (method.cls and method.cls != cls and
                             method_name != '__init__' and
                             method.method_type == MethodType.normal and
-                            not method.interface):
+                            not method.interface and
+                            not method.contract_only):
                         # Inherited
                         methods.append(self.create_inherit_check(method, cls,
                                                                  ctx))

--- a/tests/functional/verification/issues/00096.py
+++ b/tests/functional/verification/issues/00096.py
@@ -1,0 +1,26 @@
+from nagini_contracts.contracts import *
+from nagini_contracts.obligations import MustTerminate
+from nagini_contracts.thread import Thread
+
+
+class Cell:
+
+     def __init__(self) -> None:
+         Ensures(Acc(self.x))
+         self.x = 0  # type: int
+
+     def void(self) -> None:
+         Requires(Acc(self.x, 1/4))
+         Requires(MustTerminate(2))
+         Ensures(Acc(self.x, 1/4))
+
+     def a12(self, a: int) -> None:
+         Requires(Acc(self.x, 1/2))
+         Ensures(Acc(self.x, 1/2))
+         i = 0  # type: int
+         while i < a:
+             Invariant(Acc(self.x, 1/2))
+             t1 = Thread(None, self.void, args=())
+             t1.start(self.void)
+             t1.join(self.void)
+             i += 1

--- a/tests/functional/verification/test_lock.py
+++ b/tests/functional/verification/test_lock.py
@@ -1,0 +1,113 @@
+from nagini_contracts.lock import Lock
+from nagini_contracts.contracts import *
+from nagini_contracts.obligations import Level, WaitLevel
+
+
+class Cell:
+    def __init__(self, val: int) -> None:
+        self.value = val
+        Ensures(Acc(self.value) and self.value == val)
+
+
+class CellLock(Lock[Cell]):
+
+    @Predicate
+    def invariant(self) -> bool:
+        return Acc(self.get_locked().value)
+
+
+class ThingWithCell:
+    def __init__(self) -> None:
+        self.c = Cell(12)
+        self.c.value = 14
+        self.l = CellLock(self.c)
+        #:: ExpectedOutput(assignment.failed:insufficient.permission)
+        self.c.value = 16
+        Ensures(Acc(self.c) and Acc(self.l) and self.l.get_locked() is self.c)
+        Ensures(WaitLevel() < Level(self.l))
+
+    def do_a_thing(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2) and self.l.get_locked() is self.c)
+        Requires(WaitLevel() < Level(self.l))
+        Ensures(Acc(self.l, 1 / 2) and Acc(self.c, 1 / 2))
+        #:: ExpectedOutput(postcondition.violated:assertion.false)
+        Ensures(False)
+        self.l.acquire()
+        Unfold(self.l.invariant())
+        self.c.value += 2
+        Fold(self.l.invariant())
+        self.l.release()
+
+    def do_a_thing_2(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2) and self.l.get_locked() is self.c)
+        Requires(WaitLevel() < Level(self.l))
+        self.l.acquire()
+        Unfold(self.l.invariant())
+        self.c.value += 2
+        #:: ExpectedOutput(call.precondition:insufficient.permission)
+        self.l.release()
+
+    def do_a_thing_3(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2))
+        Requires(WaitLevel() < Level(self.l))
+        Ensures(Acc(self.l, 1 / 2) and Acc(self.c, 1 / 2))
+        self.l.acquire()
+        Unfold(self.l.invariant())
+        #:: ExpectedOutput(assignment.failed:insufficient.permission)|ExpectedOutput(carbon)(application.precondition:assertion.false)
+        self.c.value += 2
+        Fold(self.l.invariant())
+        self.l.release()
+
+    def do_a_thing_4(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2) and self.l.get_locked() is self.c)
+        Ensures(Acc(self.l, 1 / 2) and Acc(self.c, 1 / 2))
+        #:: ExpectedOutput(call.precondition:assertion.false)
+        self.l.acquire()
+        Unfold(self.l.invariant())
+        self.c.value += 2
+        Fold(self.l.invariant())
+        self.l.release()
+
+    #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
+    def do_a_thing_5(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2) and self.l.get_locked() is self.c)
+        Requires(WaitLevel() < Level(self.l))
+        Ensures(Acc(self.l, 1 / 2) and Acc(self.c, 1 / 2))
+        self.l.acquire()
+        Unfold(self.l.invariant())
+        self.c.value += 2
+        Fold(self.l.invariant())
+
+    def do_a_thing_6(self) -> None:
+        Requires(Acc(self.l, 1/2) and Acc(self.c, 1/2) and self.l.get_locked() is self.c)
+        Requires(WaitLevel() < Level(self.l))
+        Ensures(Acc(self.l, 1 / 2) and Acc(self.c, 1 / 2))
+        #:: ExpectedOutput(unfold.failed:insufficient.permission)
+        Unfold(self.l.invariant())
+        self.c.value += 2
+        Fold(self.l.invariant())
+        self.l.release()
+
+
+def client_1() -> None:
+    twc = ThingWithCell()
+    twc.l.acquire()
+    twc.l.release()
+    twc.do_a_thing()
+
+
+def client_2() -> None:
+    twc = ThingWithCell()
+    twc.do_a_thing()
+
+
+class NCell:
+    def __init__(self, val: int) -> None:
+        Ensures(Acc(self.n) and self.n == 0)
+        self.n = 0  # type: int
+
+
+class NCellLock(Lock[NCell]):
+    @Predicate
+    def invariant(self) -> bool:
+        return Acc(self.get_locked().n) and self.get_locked().n >= 0

--- a/tests/obligations/verification/chalice2silver/aliasingRelease.py
+++ b/tests/obligations/verification/chalice2silver/aliasingRelease.py
@@ -13,38 +13,42 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def rel_now(a: Lock) -> None:
+def rel_now(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
     Requires(MustTerminate(2))
+    Requires(a.invariant())
     a.release()
 
 
-def rel_later(a: Lock) -> None:
+def rel_later(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 5))
     Requires(MustTerminate(2))
+    Requires(a.invariant())
     a.release()
 
 
-def f(a: Lock, b: Lock) -> None:
+def f(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(a is b)
     Requires(MustRelease(a, 3))
+    Requires(a.invariant())
     rel_now(b)
 
 
-def f_fail(a: Lock, b: Lock) -> None:
+def f_fail(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(a is b)
     Requires(MustRelease(a, 3))
+    Requires(b.invariant())
     #:: ExpectedOutput(call.precondition:insufficient.permission)
     rel_later(b)
 
 
-def fprecond(a: Lock, b: Lock) -> None:
+def fprecond(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(a is b)
@@ -55,11 +59,13 @@ def fprecond(a: Lock, b: Lock) -> None:
     Assert(False)
 
 
-def f_ok(a: Lock, b: Lock) -> None:
+def f_ok(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(MustRelease(a, 7))
     Requires(MustRelease(b, 8))
+    Requires(a.invariant())
+    Requires(b.invariant())
 
     if a is b:
         Assert(False)
@@ -68,11 +74,13 @@ def f_ok(a: Lock, b: Lock) -> None:
     rel_later(b)
 
 
-def f_leak(a: Lock, b: Lock) -> None:
+def f_leak(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(MustRelease(a, 7))
     Requires(MustRelease(b, 3))
+    Requires(a.invariant())
+    Requires(b.invariant())
 
     # TODO: Find out why Silicon needs this additional assert. Is this
     # an instance of conjunctive aliasing problem?
@@ -82,19 +90,22 @@ def f_leak(a: Lock, b: Lock) -> None:
     rel_later(a)
 
 
-def f_ok_1(a: Lock, b: Lock) -> None:
+def f_ok_1(a: Lock[object], b: Lock[object]) -> None:
     Requires(a is not None)
     Requires(b is not None)
     Requires(a is not b)
     Requires(MustRelease(a, 7))
     Requires(MustRelease(b, 3))
+    Requires(a.invariant())
+    Requires(b.invariant())
 
     rel_now(b)
     rel_later(a)
 
 
-def af(a: Lock, b: Lock) -> None:
+def af(a: Lock[object], b: Lock[object]) -> None:
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
     if a is b:
         b.release()
     else:
@@ -102,8 +113,9 @@ def af(a: Lock, b: Lock) -> None:
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def af_leak(a: Lock, b: Lock) -> None:
+def af_leak(a: Lock[object], b: Lock[object]) -> None:
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     if a is b:
         b.release()

--- a/tests/obligations/verification/chalice2silver/christian/lt_call.py
+++ b/tests/obligations/verification/chalice2silver/christian/lt_call.py
@@ -21,7 +21,7 @@ class A:
 
     def __init__(self) -> None:
         Ensures(Acc(self.a) and Acc(self.b))
-        self.a = None   # type: Optional[Lock]
+        self.a = None   # type: Optional[Lock[A]]
         self.b = 0      # type: int
 
     def d3(self) -> None:
@@ -56,19 +56,20 @@ class A:
         Requires(Acc(other.b))
         Requires(MustRelease(other.a, other.b))
         Requires(other.b >= 2)
+        Requires(other.a.invariant())
 
         other.a.release()
 
     def timed_release_unbounded(self) -> None:
         x = A()
-        x.a = Lock()
+        x.a = Lock(x)
         x.a.acquire()
         x.b = 15
         self.quick_release(x)
 
     def timed_release_unbounded_subzero(self) -> None:
         x = A()
-        x.a = Lock()
+        x.a = Lock(x)
         x.a.acquire()
         x.b = -1
         #:: ExpectedOutput(call.precondition:obligation_measure.non_positive)
@@ -87,16 +88,16 @@ class A:
         Requires(Acc(other.b))
         Requires(MustRelease(other.a, other.b))
 
-        #:: ExpectedOutput(call.precondition:assertion.false)|ExpectedOutput(carbon)(call.precondition:insufficient.permission)
+        #:: ExpectedOutput(call.precondition:assertion.false)|ExpectedOutput(carbon)(call.precondition:insufficient.permission)|ExpectedOutput(carbon)(call.precondition:insufficient.permission)
         self.quick_release(other)
 
     def timed_release_bounded_statdec(self, other: 'A') -> None:
-        Requires(Acc(other.a) and Acc(other.b))
+        Requires(Acc(other.a) and Acc(other.b) and other.a.invariant())
         Requires(other.b > 5 and MustRelease(other.a,other.b+1))
         self.quick_release(other)
 
     def timed_release_bounded_mutdec(self, other: 'A') -> None:
-        Requires(Acc(other.a) and Acc(other.b) and other.b > 2)
+        Requires(Acc(other.a) and Acc(other.b) and other.b > 2 and other.a.invariant())
         Requires(MustRelease(other.a, other.b))
         other.b -= 1
         self.quick_release(other)

--- a/tests/obligations/verification/chalice2silver/christian/lt_loops.py
+++ b/tests/obligations/verification/chalice2silver/christian/lt_loops.py
@@ -9,9 +9,11 @@ from nagini_contracts.contracts import (
     Acc,
     Assert,
     Ensures,
+    Fold,
     Implies,
     Invariant,
     Requires,
+    Unfold,
 )
 from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
@@ -21,7 +23,7 @@ from typing import Optional
 class A:
 
     def __init__(self) -> None:
-        self.a = None       # type: Optional[Lock]
+        self.a = None       # type: Optional[Lock[A]]
         self.b = 0          # type: int
 
     def m1(self) -> None:
@@ -100,19 +102,23 @@ class A:
     def m8(self) -> None:
         Requires(Acc(self.b) and self.b > 17)
         Requires(Acc(self.a) and MustRelease(self.a, self.b))
+        Requires(self.a.invariant())
 
         while self.b > 2:
             Invariant(Acc(self.b) and MustTerminate(self.b))
             self.b -= 1
+        Fold(self.a.invariant())
         self.a.release()
 
     def m9(self) -> None:
         Requires(Acc(self.b) and self.b > 17)
         Requires(Acc(self.a) and MustRelease(self.a, self.b))
+        Requires(self.a.invariant())
 
         while self.b > 2:
             Invariant(Acc(self.a) and Acc(self.b))
             Invariant(Implies(self.b > 4, MustRelease(self.a, self.b)))
+            Invariant(Implies(self.b > 4, self.a.invariant()))
             if self.b > 4:
                 self.b -= 1
                 if self.b == 4:
@@ -121,18 +127,22 @@ class A:
     def m10(self) -> None:
         Requires(Acc(self.a) and MustRelease(self.a, 2))
         Requires(WaitLevel() < Level(self.a))
+        Requires(self.a.invariant())
         while True:
             Invariant(Acc(self.a) and MustRelease(self.a, 1))
             Invariant(WaitLevel() < Level(self.a))
+            Invariant(self.a.invariant())
             self.a.release()
             self.a.acquire()
 
     def m11(self) -> None:
         Requires(Acc(self.a) and MustRelease(self.a, 2))
         Requires(WaitLevel() < Level(self.a))
+        Requires(self.a.invariant())
         while True:
             Invariant(Acc(self.a) and MustRelease(self.a, 1))
             Invariant(WaitLevel() < Level(self.a))
+            Invariant(self.a.invariant())
             self.a.release()
             self.a.acquire()
             #:: ExpectedOutput(assert.failed:assertion.false)

--- a/tests/obligations/verification/chalice2silver/christian/obl_loop.py
+++ b/tests/obligations/verification/chalice2silver/christian/obl_loop.py
@@ -21,11 +21,12 @@ from typing import Optional
 class A:
 
     def __init__(self) -> None:
-        self.x = None   # type: Optional[Lock]
+        self.x = None   # type: Optional[Lock[A]]
         self.y = 0
 
     def m1_hide(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         #:: ExpectedOutput(leak_check.failed:loop_context.has_unsatisfied_obligations)
         while x < 5:
@@ -34,6 +35,7 @@ class A:
 
     def m2_hide(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         while x < 5:
             Invariant(MustTerminate(10-x))
@@ -42,29 +44,35 @@ class A:
 
     def m2_transfer_rel(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(Implies(x < 5, MustRelease(self.x, 10-x)))
+            Invariant(Implies(x < 5, self.x.invariant()))
             x += 1
             if x >= 5:
                 self.x.release()
 
     def m2_borrow_rel(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(MustRelease(self.x, 10-x))
+            Invariant(self.x.invariant())
             x += 1
         self.x.release()
 
     def nested1(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         y = 1
         while x < 5:
             Invariant(Acc(self.x) and MustRelease(self.x, 10 - x))
+            Invariant(self.x.invariant())
             x += 1
             #:: ExpectedOutput(leak_check.failed:loop_context.has_unsatisfied_obligations)
             while y < 5:
@@ -73,11 +81,13 @@ class A:
 
     def nested1_after_inner(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         y = 1
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(Implies(x < 5, MustRelease(self.x, 10 - x)))
+            Invariant(Implies(x < 5, self.x.invariant()))
             x += 1
             #:: ExpectedOutput(leak_check.failed:loop_context.has_unsatisfied_obligations)
             while y < 5:
@@ -87,11 +97,13 @@ class A:
 
     def nested2(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         y = 1
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(MustRelease(self.x, 10 - x))
+            Invariant(self.x.invariant())
             x += 1
             while y < 5:
                 Invariant(MustTerminate(20 - y))
@@ -100,11 +112,13 @@ class A:
 
     def nested2_after_inner(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         x = 1
         y = 1
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(Implies(x < 5, MustRelease(self.x, 10 - x)))
+            Invariant(Implies(x < 5, self.x.invariant()))
             x += 1
             while y < 5:
                 Invariant(MustTerminate(20 - y))
@@ -115,12 +129,14 @@ class A:
     def nested3(self) -> None:
         Requires(Acc(self.x) and self.x is not None)
         Requires(WaitLevel() < Level(self.x))
+        Requires(self.x.invariant())
         x = 1
         y = 1
         self.x.acquire()
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(MustRelease(self.x, 10 - x))
+            Invariant(self.x.invariant())
             x += 1
             #:: ExpectedOutput(leak_check.failed:loop_context.has_unsatisfied_obligations)
             while y < 5:
@@ -130,16 +146,19 @@ class A:
     def nested4(self) -> None:
         Requires(Acc(self.x) and self.x is not None)
         Requires(WaitLevel() < Level(self.x))
+        Requires(self.x.invariant())
         x = 1
         self.x.acquire()
         while x < 5:
             Invariant(Acc(self.x))
             Invariant(Implies(x < 5, MustRelease(self.x, 10 - x)))
+            Invariant(Implies(x < 5, self.x.invariant()))
             x += 1
             y = 1
             while y < 5:
                 Invariant(Acc(self.x))
                 Invariant(Implies(y < 5 or x < 5, MustRelease(self.x, 10 - y)))
+                Invariant(Implies(y < 5 or x < 5, self.x.invariant()))
                 y += 1
                 if y == 5 and x == 5:
                     self.x.release()

--- a/tests/obligations/verification/chalice2silver/christian/obl_pre_rel.py
+++ b/tests/obligations/verification/chalice2silver/christian/obl_pre_rel.py
@@ -21,16 +21,18 @@ from typing import Optional
 class A:
 
     def __init__(self) -> None:
-        self.x = None   # type: Optional[Lock]
+        self.x = None   # type: Optional[Lock[A]]
         self.y = 0
 
     def t(self) -> None:
         Requires(Acc(self.x) and MustRelease(self.x, 2))
+        Requires(self.x.invariant())
         Ensures(Acc(self.x))
         self.x.release()
 
     def mr(self, other: 'A') -> None:
         Requires(Acc(other.x) and MustRelease(other.x, 2))
+        Requires(other.x.invariant())
         Ensures(Acc(other.x))
         other.x.release()
 

--- a/tests/obligations/verification/chalice2silver/issues/chalice2silver-77-3.py
+++ b/tests/obligations/verification/chalice2silver/issues/chalice2silver-77-3.py
@@ -14,7 +14,7 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def test1(l: Lock) -> None:
+def test1(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     l.acquire()
@@ -24,7 +24,7 @@ def test1(l: Lock) -> None:
     l.release()
 
 
-def test2(l: Lock) -> None:
+def test2(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     i = 0
@@ -35,7 +35,7 @@ def test2(l: Lock) -> None:
     l.release()
 
 
-def test3(l: Lock) -> None:
+def test3(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     i = 0

--- a/tests/obligations/verification/chalice2silver/issues/chalice2silver-82.py
+++ b/tests/obligations/verification/chalice2silver/issues/chalice2silver-82.py
@@ -13,29 +13,33 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def test1(l: Lock) -> None:
+def test1(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     l.acquire()
     while True:
         Invariant(MustRelease(l, 1))
         Invariant(WaitLevel() < Level(l))
+        Invariant(l.invariant())
         do_release(l)
         l.acquire()
 
 
-def test2(l: Lock) -> None:
+def test2(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(MustRelease(l, 3))
     Requires(WaitLevel() < Level(l))
+    Requires(l.invariant())
     while True:
         Invariant(MustRelease(l, 1))
         Invariant(WaitLevel() < Level(l))
+        Invariant(l.invariant())
         do_release(l)
         l.acquire()
 
 
-def do_release(l: Lock) -> None:
+def do_release(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(MustRelease(l, 2))
+    Requires(l.invariant())
     l.release()

--- a/tests/obligations/verification/chalice2silver/issues/chalice2silver-83.py
+++ b/tests/obligations/verification/chalice2silver/issues/chalice2silver-83.py
@@ -13,12 +13,12 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def foo(l: Lock) -> None:
+def foo(l: Lock[object]) -> None:
     Requires(MustRelease(l, 2))
     Ensures(MustRelease(l, 2))
 
 
-def caller(l: Lock) -> None:
+def caller(l: Lock[object]) -> None:
     Requires(MustRelease(l, 3))
     Ensures(False)
 

--- a/tests/obligations/verification/chalice2silver/largerExamples/watchdog.py
+++ b/tests/obligations/verification/chalice2silver/largerExamples/watchdog.py
@@ -25,7 +25,7 @@ class WatchDog:
     def delay(self, t: int) -> None:
         Requires(MustTerminate(t))
 
-    def watch(self, d: Lock) -> None:
+    def watch(self, d: Lock['WatchDog']) -> None:
         Requires(d is not None)
         Requires(Acc(self.running))
         Requires(WaitLevel() < Level(d))
@@ -36,6 +36,7 @@ class WatchDog:
             Invariant(Acc(self.running))
             Invariant(MustRelease(d, 1))
             Invariant(WaitLevel() < Level(d))
+            Invariant(d.invariant())
             # TODO: Check some property here.
             d.release()
             self.delay(5)

--- a/tests/obligations/verification/chalice2silver/leakCheckCall.py
+++ b/tests/obligations/verification/chalice2silver/leakCheckCall.py
@@ -25,43 +25,48 @@ def s() -> None:
     Requires(MustTerminate(1))
 
 
-def g(a: Lock) -> None:
+def g(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     #:: ExpectedOutput(leak_check.failed:caller.has_unsatisfied_obligations)
     t()
     a.release()
 
 
-def g1(a: Lock) -> None:
+def g1(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     s()
     a.release()
 
 
-def g2(a: Lock) -> None:
+def g2(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     a.release()
     t()
 
 
-def g3(a: Lock) -> None:
+def g3(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     s()
     a.release()
     t()
 
 
-def h1(a: Lock) -> None:
+def h1(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     #:: ExpectedOutput(leak_check.failed:caller.has_unsatisfied_obligations)
     t()
@@ -69,7 +74,7 @@ def h1(a: Lock) -> None:
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def h2(a: Lock) -> None:
+def h2(a: Lock[object]) -> None:
     Requires(MustTerminate(5))
     Requires(a is not None)
     Requires(MustRelease(a, 2))
@@ -77,9 +82,10 @@ def h2(a: Lock) -> None:
     s()
 
 
-def h3(a: Lock) -> None:
+def h3(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
 
     #:: ExpectedOutput(leak_check.failed:caller.has_unsatisfied_obligations)
     t()

--- a/tests/obligations/verification/chalice2silver/lifetime.py
+++ b/tests/obligations/verification/chalice2silver/lifetime.py
@@ -13,7 +13,7 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def do_release(l: Lock) -> None:
+def do_release(l: Lock[object]) -> None:
     Requires(l is not None)
     #:: Label(do_release__MustTerminate)
     Requires(MustRelease(l, 0))
@@ -21,7 +21,7 @@ def do_release(l: Lock) -> None:
     l.release()
 
 
-def do_release_caller(l: Lock) -> None:
+def do_release_caller(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(MustRelease(l, 1))
 

--- a/tests/obligations/verification/chalice2silver/loopsAndRelease.py
+++ b/tests/obligations/verification/chalice2silver/loopsAndRelease.py
@@ -14,19 +14,21 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def rel_now(a: Lock) -> None:
+def rel_now(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
     a.release()
 
 
-def rel_later(a: Lock) -> None:
+def rel_later(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 10))
+    Requires(a.invariant())
     a.release()
 
 
-def f(a: Lock) -> None:
+def f(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 
@@ -40,7 +42,7 @@ def f(a: Lock) -> None:
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def f_leak(a: Lock) -> None:
+def f_leak(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 
@@ -52,7 +54,7 @@ def f_leak(a: Lock) -> None:
         i += 1
 
 
-def f_leak2(a: Lock) -> None:
+def f_leak2(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 

--- a/tests/obligations/verification/chalice2silver/returningObligations.py
+++ b/tests/obligations/verification/chalice2silver/returningObligations.py
@@ -15,45 +15,50 @@ from nagini_contracts.obligations import *
 from nagini_contracts.lock import Lock
 
 
-def reAcq(a: Lock) -> None:
+def reAcq(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
     Ensures(MustRelease(a, 2))
+    Ensures(a.invariant())
     a.release()
     a.acquire()
 
 
-def reAcq2(a: Lock) -> None:
+def reAcq2(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
     Ensures(MustRelease(a, 2))
 
 
-def reAcq3(a: Lock) -> None:
+def reAcq3(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
     Requires(MustRelease(a, 2))
+    Requires(a.invariant())
     Ensures(MustRelease(a))
+    Ensures(a.invariant())
     a.release()
     a.acquire()
 
 
-def reAcq4(a: Lock) -> None:
+def reAcq4(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(MustRelease(a, 2))
     #:: ExpectedOutput(postcondition.violated:insufficient.permission)
     Ensures(MustRelease(a))
 
 
-def acq(a: Lock) -> None:
+def acq(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
     Ensures(MustRelease(a, 5))
+    Ensures(a.invariant())
     a.acquire()
 
 
-def continuous1(a: Lock) -> None:
+def continuous1(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 
@@ -63,12 +68,13 @@ def continuous1(a: Lock) -> None:
         #:: ExpectedOutput(invariant.not.preserved:insufficient.permission)
         Invariant(MustRelease(a, 3))
         Invariant(WaitLevel() < Level(a))
+        Invariant(a.invariant())
         a.release()
         a.acquire()
         reAcq(a)
 
 
-def continuous2(a: Lock) -> None:
+def continuous2(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 
@@ -78,12 +84,13 @@ def continuous2(a: Lock) -> None:
         #:: ExpectedOutput(invariant.not.preserved:insufficient.permission)
         Invariant(MustRelease(a, 3))
         Invariant(WaitLevel() < Level(a))
+        Invariant(a.invariant())
         a.release()
         a.acquire()
         reAcq2(a)
 
 
-def continuous3(a: Lock) -> None:
+def continuous3(a: Lock[object]) -> None:
     Requires(a is not None)
     Requires(WaitLevel() < Level(a))
 
@@ -92,6 +99,7 @@ def continuous3(a: Lock) -> None:
     while True:
         Invariant(MustRelease(a, 3))
         Invariant(WaitLevel() < Level(a))
+        Invariant(a.invariant())
         a.release()
         a.acquire()
         reAcq3(a)

--- a/tests/obligations/verification/test_behavioral_subtyping.py
+++ b/tests/obligations/verification/test_behavioral_subtyping.py
@@ -12,8 +12,9 @@ class Super:
         Requires(MustTerminate(2))
 
     #:: Label(Super__release)
-    def release(self, lock: Lock) -> None:
+    def release(self, lock: Lock['Super']) -> None:
         Requires(MustRelease(lock, 3))
+        Requires(lock.invariant())
         lock.release()
 
 
@@ -25,9 +26,10 @@ class SubIncreased(Super):
         Requires(MustTerminate(3))
 
     #:: ExpectedOutput(call.precondition:insufficient.permission, Super__release)
-    def release(self, lock: Lock) -> None:
+    def release(self, lock: Lock[Super]) -> None:
         """Measure increased. Error."""
         Requires(MustRelease(lock, 4))
+        Requires(lock.invariant())
         lock.release()
 
 
@@ -46,9 +48,10 @@ class SubDecreased(Super):
         """Measure decreased. Ok."""
         Requires(MustTerminate(1))
 
-    def release(self, lock: Lock) -> None:
+    def release(self, lock: Lock[Super]) -> None:
         """Measure decreased. Ok."""
         Requires(MustRelease(lock, 2))
+        Requires(lock.invariant())
         lock.release()
 
 
@@ -58,7 +61,8 @@ class SubUnchanged(Super):
         """Measure the same. Ok."""
         Requires(MustTerminate(2))
 
-    def release(self, lock: Lock) -> None:
+    def release(self, lock: Lock[Super]) -> None:
         """Measure the same. Ok."""
         Requires(MustRelease(lock, 3))
+        Requires(lock.invariant())
         lock.release()

--- a/tests/obligations/verification/test_loop_leak_check.py
+++ b/tests/obligations/verification/test_loop_leak_check.py
@@ -16,7 +16,7 @@ def MustInvoke_context_1(t1: Place) -> None:
         i += 1
 
 
-def MustRelease_context_1(lock: Lock) -> None:
+def MustRelease_context_1(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     i = 0
     #:: ExpectedOutput(leak_check.failed:loop_context.has_unsatisfied_obligations)
@@ -34,7 +34,7 @@ def MustInvoke_context_2(t1: Place) -> None:
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def MustRelease_context_2(lock: Lock) -> None:
+def MustRelease_context_2(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     i = 0
     while i < 5:
@@ -53,7 +53,7 @@ def MustInvoke_body_1(t1: Place) -> None:
 
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
-def MustRelease_body_1(lock: Lock) -> None:
+def MustRelease_body_1(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     i = 0
     while i < 5:
@@ -72,7 +72,7 @@ def MustInvoke_body_2(t1: Place) -> None:
         i += 1
 
 
-def MustRelease_body_2(lock: Lock) -> None:
+def MustRelease_body_2(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     i = 0
     #:: ExpectedOutput(carbon)(leak_check.failed:loop_body.leaks_obligations)

--- a/tests/obligations/verification/test_method_leak_check.py
+++ b/tests/obligations/verification/test_method_leak_check.py
@@ -31,26 +31,26 @@ def MustInvoke_body(t1: Place) -> None:
     Requires(token(t1, 1))
 
 
-def MustRelease_callee_1(lock: Lock) -> None:
+def MustRelease_callee_1(lock: Lock[object]) -> None:
     pass
 
 
-def MustRelease_caller_1(lock: Lock) -> None:
+def MustRelease_caller_1(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     #:: ExpectedOutput(leak_check.failed:caller.has_unsatisfied_obligations)
     MustRelease_callee_1(lock)
 
 
-def MustRelease_callee_2(lock: Lock) -> None:
+def MustRelease_callee_2(lock: Lock[object]) -> None:
     Requires(MustTerminate(1))
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def MustRelease_caller_2(lock: Lock) -> None:
+def MustRelease_caller_2(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))
     MustRelease_callee_2(lock)
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def MustRelease_body(lock: Lock) -> None:
+def MustRelease_body(lock: Lock[object]) -> None:
     Requires(MustRelease(lock, 1))

--- a/tests/obligations/verification/test_must_release.py
+++ b/tests/obligations/verification/test_must_release.py
@@ -15,33 +15,33 @@ from typing import Optional
 
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
-def acquire_1(l: Optional[Lock]) -> None:
+def acquire_1(l: Optional[Lock[object]]) -> None:
     #:: ExpectedOutput(call.precondition:assertion.false)|UnexpectedOutput(carbon)(call.precondition:assertion.false, 168)
     l.acquire()
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def acquire_2(l: Lock) -> None:
+def acquire_2(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     l.acquire()
 
 
-def acquire_3(l: Lock) -> None:
+def acquire_3(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     l.acquire()
     l.release()
 
 
-def acquire_4(l: Lock) -> None:
+def acquire_4(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     Ensures(MustRelease(l))
     l.acquire()
 
 
-def acquire_5(l: Lock) -> None:
+def acquire_5(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     Ensures(MustRelease(l, 10))
@@ -51,18 +51,21 @@ def acquire_5(l: Lock) -> None:
 # Check releasing a lock.
 
 
-def release_1(l: Lock) -> None:
+def release_1(l: Lock[object]) -> None:
     Requires(MustRelease(l, 2))
+    Requires(l.invariant())
     l.release()
 
 
-def release_2(l: Lock) -> None:
+def release_2(l: Lock[object]) -> None:
+    Requires(l.invariant())
     #:: ExpectedOutput(call.precondition:insufficient.permission)
     l.release()
 
 
-def release_3(l: Lock) -> None:
+def release_3(l: Lock[object]) -> None:
     Requires(l is not None)
+    Requires(l.invariant())
     #:: ExpectedOutput(call.precondition:insufficient.permission)
     l.release()
 
@@ -72,27 +75,28 @@ def release_3(l: Lock) -> None:
 
 def terminating_1() -> None:
     Requires(MustTerminate(2))
-    l = Lock()
+    l = Lock(object())
 
 
 #:: ExpectedOutput(leak_check.failed:method_body.leaks_obligations)
-def terminating_2(l: Lock) -> None:
+def terminating_2(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     Requires(MustTerminate(2))
     l.acquire()
 
 
-def terminating_3(l: Lock) -> None:
+def terminating_3(l: Lock[object]) -> None:
     Requires(MustRelease(l, 2))
     Requires(MustTerminate(2))
+    Requires(l.invariant())
     l.release()
 
 
 # Check that measures are positive in methods.
 
 
-def over_in_minus_one(l: Lock) -> None:
+def over_in_minus_one(l: Lock[object]) -> None:
     #:: Label(over_in_minus_one__MustRelease)
     Requires(MustRelease(l, -1))
     # Negative measure is equivalent to False.
@@ -100,13 +104,13 @@ def over_in_minus_one(l: Lock) -> None:
 
 
 def check_over_in_minus_one() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     #:: ExpectedOutput(call.precondition:obligation_measure.non_positive)
     over_in_minus_one(l)
 
 
-def over_in_minus_one_conditional(l: Lock, b: bool) -> None:
+def over_in_minus_one_conditional(l: Lock[object], b: bool) -> None:
     Requires(Implies(b, MustRelease(l, 1)))
     #:: Label(over_in_minus_one_conditional__MustRelease__False)
     Requires(Implies(not b, MustRelease(l, -1)))
@@ -117,13 +121,13 @@ def over_in_minus_one_conditional(l: Lock, b: bool) -> None:
 
 
 def check_over_in_minus_one_conditional_1() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     over_in_minus_one_conditional(l, True)
 
 
 def check_over_in_minus_one_conditional_2() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     #:: ExpectedOutput(call.precondition:obligation_measure.non_positive)
     over_in_minus_one_conditional(l, False)
@@ -133,7 +137,7 @@ def check_over_in_minus_one_conditional_2() -> None:
 
 
 def test_measures_1() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     while True:
         #:: ExpectedOutput(invariant.not.established:obligation_measure.non_positive)
@@ -142,7 +146,7 @@ def test_measures_1() -> None:
 
 
 def test_measures_2() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     while False:
         # Negative measure is ok because loop is never executed.
@@ -152,7 +156,7 @@ def test_measures_2() -> None:
 
 
 def test_measures_3() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     i = 5
     while i > 0:
@@ -162,7 +166,7 @@ def test_measures_3() -> None:
 
 
 def test_measures_4() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     i = 5
     while i > -1:
@@ -184,7 +188,7 @@ class A:
 
 def test_loop_condition_framing_1() -> None:
     a = A()
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     i = 5
     #:: UnexpectedOutput(carbon)(application.precondition:assertion.false, 70)
@@ -200,7 +204,7 @@ def test_loop_condition_framing_1() -> None:
 
 def test_loop_condition_framing_2() -> None:
     a = A()
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     i = 5
     while a.steps < 5:

--- a/tests/obligations/verification/test_waitlevels.py
+++ b/tests/obligations/verification/test_waitlevels.py
@@ -14,7 +14,7 @@ from nagini_contracts.lock import Lock
 # Creating locks.
 
 def create_lock() -> None:
-    l = Lock()
+    l = Lock(object())
     l.acquire()
     l.release()
     #:: ExpectedOutput(assert.failed:assertion.false)
@@ -23,8 +23,8 @@ def create_lock() -> None:
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
 def create_lock_unknown_order_1() -> None:
-    l1 = Lock()
-    l2 = Lock()
+    l1 = Lock(object())
+    l2 = Lock(object())
     l1.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
     l2.acquire()
@@ -32,16 +32,16 @@ def create_lock_unknown_order_1() -> None:
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
 def create_lock_unknown_order_2() -> None:
-    l1 = Lock()
-    l2 = Lock()
+    l1 = Lock(object())
+    l2 = Lock(object())
     l2.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
     l1.acquire()
 
 
 def create_lock_above_1() -> None:
-    l1 = Lock()
-    l2 = Lock(above=l1)
+    l1 = Lock(object())
+    l2 = Lock(object(), above=l1)
     l1.acquire()
     l2.acquire()
     l1.release()
@@ -49,24 +49,24 @@ def create_lock_above_1() -> None:
 
 
 def create_lock_above_2() -> None:
-    l1 = Lock()
-    l2 = Lock(above=l1)
+    l1 = Lock(object())
+    l2 = Lock(object(), above=l1)
     l2.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
     l1.acquire()
 
 
 def create_lock_below_1() -> None:
-    l1 = Lock()
-    l2 = Lock(below=l1)
+    l1 = Lock(object())
+    l2 = Lock(object(), below=l1)
     l1.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
     l2.acquire()
 
 
 def create_lock_below_2() -> None:
-    l1 = Lock()
-    l2 = Lock(below=l1)
+    l1 = Lock(object())
+    l2 = Lock(object(), below=l1)
     l2.acquire()
     l1.acquire()
     l1.release()
@@ -74,17 +74,17 @@ def create_lock_below_2() -> None:
 
 
 def create_lock_below_3() -> None:
-    l1 = Lock()
+    l1 = Lock(object())
     l1.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
-    l2 = Lock(below=l1)
+    l2 = Lock(object(), below=l1)
 
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
 def create_lock_between_1() -> None:
-    l1 = Lock()
-    l3 = Lock(below=l1)
-    l2 = Lock(above=l3, below=l1)
+    l1 = Lock(object())
+    l3 = Lock(object(), below=l1)
+    l2 = Lock(object(), above=l3, below=l1)
     l3.acquire()
     l2.acquire()
     l1.acquire()
@@ -94,9 +94,9 @@ def create_lock_between_1() -> None:
 
 
 def create_lock_between_2() -> None:
-    l1 = Lock()
-    l3 = Lock(below=l1)
-    l2 = Lock(above=l3, below=l1)
+    l1 = Lock(object())
+    l3 = Lock(object(), below=l1)
+    l2 = Lock(object(), above=l3, below=l1)
     l1.acquire()
     #:: ExpectedOutput(call.precondition:assertion.false)
     l2.acquire()
@@ -104,28 +104,29 @@ def create_lock_between_2() -> None:
 
 
 def create_lock_between_3() -> None:
-    l1 = Lock()
-    l3 = Lock(above=l1)
+    l1 = Lock(object())
+    l3 = Lock(object(), above=l1)
     #:: ExpectedOutput(call.precondition:assertion.false)
-    l2 = Lock(above=l3, below=l1)
+    l2 = Lock(object(), above=l3, below=l1)
 
 
 # Methods.
 
 
-def release(l: Lock) -> None:
+def release(l: Lock[object]) -> None:
     Requires(MustRelease(l, 2))
+    Requires(l.invariant())
     l.release()
 
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
-def acquire(l: Lock) -> None:
+def acquire(l: Lock[object]) -> None:
     Requires(l is not None)
     #:: ExpectedOutput(call.precondition:assertion.false)
     l.acquire()
 
 
-def double_acquire(l: Lock) -> None:
+def double_acquire(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     l.acquire()
@@ -133,10 +134,11 @@ def double_acquire(l: Lock) -> None:
     l.acquire()
 
 
-def acquire_release_multiple(l: Lock) -> None:
+def acquire_release_multiple(l: Lock[object]) -> None:
     Requires(l is not None)
     Requires(WaitLevel() < Level(l))
     Ensures(MustRelease(l))
+    Ensures(l.invariant())
     l.acquire()
     l.release()
     l.acquire()
@@ -145,19 +147,19 @@ def acquire_release_multiple(l: Lock) -> None:
 
 
 def acquire_release_multiple_caller_1() -> None:
-    l = Lock()
+    l = Lock(object())
     acquire_release_multiple(l)
     l.release()
 
 
 #:: ExpectedOutput(carbon)(leak_check.failed:method_body.leaks_obligations)
-def acquire_release_multiple_caller_2(l: Lock) -> None:
+def acquire_release_multiple_caller_2(l: Lock[object]) -> None:
     Requires(l is not None)
     #:: ExpectedOutput(call.precondition:assertion.false)
     acquire_release_multiple(l)
 
 
-def change_level(l: Lock) -> None:
+def change_level(l: Lock[object]) -> None:
     Requires(l is not None)
     #:: ExpectedOutput(postcondition.violated:assertion.false)
     Ensures(WaitLevel() < Level(l))
@@ -166,22 +168,22 @@ def change_level(l: Lock) -> None:
 # Loops.
 
 
-def locks_creating_loop() -> Lock:
+def locks_creating_loop() -> Lock[object]:
     Ensures(WaitLevel() < Level(Result()))
-    l = Lock()
+    l = Lock(object())
     i = 0
     while i < 5:
         Invariant(l is not None)
         Invariant(WaitLevel() < Level(l))
         l.acquire()
         l.release()
-        l = Lock()
+        l = Lock(object())
         i += 1
     return l
 
-def locks_creating_loop_nested() -> Lock:
+def locks_creating_loop_nested() -> Lock[object]:
     Ensures(WaitLevel() < Level(Result()))
-    l = Lock()
+    l = Lock(object())
     i = 0
     while i < 5:
         Invariant(l is not None)
@@ -194,7 +196,7 @@ def locks_creating_loop_nested() -> Lock:
             Invariant(WaitLevel() < Level(l))
             l.acquire()
             l.release()
-            l = Lock()
+            l = Lock(object())
             j += 1
         i += 1
     return l


### PR DESCRIPTION
Locks can have invariants now, defined by overriding the "invariant" predicate in a new subclass of Lock.

Depends on the thread pull request, this should be merged afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/104)
<!-- Reviewable:end -->
