### PR TITLE
Fix issue 124:  Verifier crashes when calling a method call that might or not return a value

### DIFF
--- a/src/nagini_translation/lib/resolver.py
+++ b/src/nagini_translation/lib/resolver.py
@@ -420,6 +420,8 @@ def _get_call_type(node: ast.Call, module: PythonModule,
                                    for type in set_of_classes}
             if len(set_of_return_types) == 1:
                 return set_of_return_types.pop()
+            elif len(set_of_return_types) == 2 and None in set_of_return_types:
+                return OptionalType((set_of_return_types - {None}).pop())
             else:
                 return UnionType(list(set_of_return_types))
         elif isinstance(rectype, PythonType):

--- a/tests/functional/verification/issues/00124.py
+++ b/tests/functional/verification/issues/00124.py
@@ -1,0 +1,24 @@
+from nagini_contracts.contracts import *
+from typing import (
+    Optional,
+    Union,
+)
+
+class A:
+    def method(self) -> None:   # Method with no return value
+        pass
+
+class B:
+    def method(self) -> int:    # Method with return value
+        return 1
+
+class C:
+    @Pure
+    def method(self) -> int:    # Method with return value (pure function)
+        return 8
+
+def test_union_mixing_return_with_no_return(u: Union[A, B]) -> None:
+    u.method()
+
+def test_union_mixing_return_with_no_return_pure(u: Union[A, C]) -> None:
+    u.method()


### PR DESCRIPTION
This fix accompany a test case that actually caused the issue to emerge. The fix covers the case where an object of OptionalType suits better than an object of UnionType.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/128)
<!-- Reviewable:end -->
