### PR TITLE
Fixing union subtype axiom

### DIFF
--- a/src/nagini_translation/resources/pytype.sil
+++ b/src/nagini_translation/resources/pytype.sil
@@ -19,6 +19,7 @@ domain PyType {
     function tuple_args(t: PyType): Seq[PyType]
     function tuple_arg(t: PyType, i: Int): PyType
     function tuple_basic(): PyType
+    function union_basic(): PyType
     function Iterator(t: PyType): PyType
     function Iterator_arg(t: PyType, i: Int): PyType
     function PSeq(t: PyType): PyType

--- a/src/nagini_translation/resources/tuple.sil
+++ b/src/nagini_translation/resources/tuple.sil
@@ -227,14 +227,14 @@ domain tuple_types {
   axiom tuple_type_basic_1 {
     (forall seq: Seq[PyType], Z: PyType, arg1: PyType ::
       { issubtype(Z, tuple(seq)), issubtype(Z, arg1) }
-      issubtype(Z, tuple(seq)) && issubtype(Z, arg1) ==> (get_basic(arg1) == tuple_basic() || get_basic(arg1) == object())
+      issubtype(Z, tuple(seq)) && issubtype(Z, arg1) ==> (get_basic(arg1) == tuple_basic() || get_basic(arg1) == object() || get_basic(arg1) == union_basic())
       )
   }
 
   axiom tuple_type_basic_2 {
     (forall arg0: PyType, arg1: PyType, Z: PyType ::
       { issubtype(Z, tuple_var(arg0)), issubtype(Z, arg1) }
-      issubtype(Z, tuple_var(arg0)) && issubtype(Z, arg1)  ==> (get_basic(arg1) == tuple_basic() || get_basic(arg1) == object())
+      issubtype(Z, tuple_var(arg0)) && issubtype(Z, arg1)  ==> (get_basic(arg1) == tuple_basic() || get_basic(arg1) == object() || get_basic(arg1) == union_basic())
       )
   }
 }

--- a/src/nagini_translation/translators/type_domain_factory.py
+++ b/src/nagini_translation/translators/type_domain_factory.py
@@ -49,6 +49,7 @@ class TypeDomainFactory:
             self.create_reflexivity_axiom(ctx),
             self.create_extends_implies_subtype_axiom(ctx),
             self.create_null_type_axiom(ctx),
+            self.create_union_basic_axiom(ctx),
             self.create_object_subtype_axiom(ctx),
             self.create_subtype_exclusion_axiom(ctx),
             self.create_subtype_exclusion_axiom_2(ctx),
@@ -620,6 +621,28 @@ class TypeDomainFactory:
         body = self.viper.Forall([arg_r], [trigger],
                                  biimplication, position, info)
         return self.viper.DomainAxiom('null_nonetype', body, position, info,
+                                      self.type_domain)
+
+    def create_union_basic_axiom(self, ctx: Context) -> 'silver.ast.DomainAxiom':
+        """
+        Creates an axiom that states that the type of null is None:
+
+        forall r: Ref :: { typeof(r) }
+          get_basic(typeof(r)) != union_basic()
+        """
+        position, info = self.no_position(ctx), self.no_info(ctx)
+        arg_r = self.viper.LocalVarDecl('r', self.viper.Ref, position, info)
+        var_r = self.viper.LocalVar('r', self.viper.Ref, position, info)
+        typeof = self.typeof(var_r, ctx)
+        basic = self.viper.DomainFuncApp('get_basic', [typeof], self.type_type(),
+                                         position, info, self.type_domain)
+        union_basic = self.viper.DomainFuncApp('union_basic', [], self.type_type(),
+                                               position, info, self.type_domain)
+        inequality = self.viper.NeCmp(basic, union_basic, position, info)
+        trigger = self.viper.Trigger([typeof], position, info)
+        body = self.viper.Forall([arg_r], [trigger],
+                                 inequality, position, info)
+        return self.viper.DomainAxiom('nothing_has_union_type', body, position, info,
                                       self.type_domain)
 
     def create_object_type(self, ctx: Context) -> 'silver.ast.DomainFunc':

--- a/tests/functional/verification/issues/00196.py
+++ b/tests/functional/verification/issues/00196.py
@@ -1,0 +1,14 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from nagini_contracts.contracts import *
+from typing import *
+
+class T():
+  def foo(self, idx: Tuple[Union[int, slice], ...]) -> Tuple[int, ...]:
+    Requires(False)
+    ...
+
+t = T()
+#:: ExpectedOutput(call.precondition:assertion.false)
+r = t.foo((1, 2))


### PR DESCRIPTION
Turns out it's not true for all types ``T1``, ``T2``, ``T3`` that ``T1 <: Union[T2, T3]`` iff ``T1 <: T2`` or ``T1 <: T3``. If ``T1`` is itself a union type it's not necessary that the entire union ``T1`` is a subtype of either ``T2`` or ``T3``, this just has to be true for all of its components.

Also, we add the assumption that no object's actual runtime type is a union type.

This fixes #196.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/197)
<!-- Reviewable:end -->
