### PR TITLE
Adding typed Result() contract function

### DIFF
--- a/src/nagini_contracts/contracts.py
+++ b/src/nagini_contracts/contracts.py
@@ -26,7 +26,7 @@ GHOST_PREFIX = "_gh_"
 
 CONTRACT_WRAPPER_FUNCS = ['Requires', 'Ensures', 'Exsures', 'Invariant', 'Decreases']
 
-CONTRACT_FUNCS = ['Assume', 'Assert', 'Old', 'Result', 'Implies', 'Forall', 'IOForall', 'Forall2', 'Forall3', 'Forall6',
+CONTRACT_FUNCS = ['Assume', 'Assert', 'Old', 'Result', 'ResultT', 'Implies', 'Forall', 'IOForall', 'Forall2', 'Forall3', 'Forall6',
                   'Exists', 'Low', 'LowVal', 'LowEvent', 'Declassify', 'TerminatesSif',
                   'Acc', 'Rd', 'Wildcard', 'Fold', 'Unfold', 'Unfolding', 'Previous',
                   'RaisedException', 'PSeq', 'PSet', 'ToSeq', 'ToMS', 'MaySet', 'MayCreate',
@@ -80,6 +80,11 @@ def Old(expr: T) -> T:
 def Result() -> Any:
     pass
 
+def ResultT(t: Type[V]) -> V:
+    """
+    Like Result() but explicitly typed to avoid Any types.
+    """
+    pass
 
 def RaisedException() -> Any:
     pass
@@ -521,6 +526,7 @@ __all__ = [
         'Refute',
         'Old',
         'Result',
+        'ResultT',
         'RaisedException',
         'Implies',
         'Forall',

--- a/src/nagini_translation/lib/resolver.py
+++ b/src/nagini_translation/lib/resolver.py
@@ -457,6 +457,8 @@ def _get_call_type(node: ast.Call, module: PythonModule,
         if node.func.id in CONTRACT_FUNCS:
             if node.func.id  == 'Result':
                 return current_function.type
+            elif node.func.id  == 'ResultT':
+                return get_target(node.args[0], containers, container)
             elif node.func.id == 'RaisedException':
                 ctxs = [cont for cont in containers if
                         hasattr(cont, 'var_aliases')]

--- a/src/nagini_translation/lib/typeinfo.py
+++ b/src/nagini_translation/lib/typeinfo.py
@@ -213,6 +213,8 @@ class TypeVisitor(TraverserVisitor):
             return
         if isinstance(node.callee, mypy.nodes.SuperExpr):
             return
+        if isinstance(node.callee, mypy.nodes.NameExpr) and node.callee.name == 'ResultT':
+            return
         for a in node.args:
             self.visit(a)
         self.visit(node.callee)

--- a/src/nagini_translation/translators/contract.py
+++ b/src/nagini_translation/translators/contract.py
@@ -89,8 +89,12 @@ class ContractTranslator(CommonTranslator):
         Translates a call to the Result() contract function to a result
         expression.
         """
-        assert len(node.args) == 0
-        type = ctx.actual_function.type
+        actual_type = ctx.actual_function.type
+        if len(node.args) == 1:
+            declared_type = self.get_target(node.args[0], ctx)
+            if declared_type != actual_type:
+                raise InvalidProgramException(node, 'incorrect.declared.type',
+                                              'ResultT declares incorrect result type.')
         if not ctx.actual_function.pure:
             if ctx.result_var is None:
                 raise InvalidProgramException(node, 'invalid.result')
@@ -1000,7 +1004,7 @@ class ContractTranslator(CommonTranslator):
         Translates calls to contract functions like Result() and Acc()
         """
         func_name = get_func_name(node)
-        if func_name == 'Result':
+        if func_name in ('Result', 'ResultT'):
             return self.translate_result(node, ctx)
         elif func_name == 'RaisedException':
             return self.translate_raised_exception(node, ctx)

--- a/src/nagini_translation/translators/contract.py
+++ b/src/nagini_translation/translators/contract.py
@@ -100,7 +100,7 @@ class ContractTranslator(CommonTranslator):
                 raise InvalidProgramException(node, 'invalid.result')
             return [], ctx.result_var.ref(node, ctx)
         else:
-            return ([], self.viper.Result(self.translate_type(type, ctx),
+            return ([], self.viper.Result(self.translate_type(actual_type, ctx),
                                           self.to_position(node, ctx),
                                           self.no_info(ctx)))
 

--- a/tests/functional/translation/test_result_2.py
+++ b/tests/functional/translation/test_result_2.py
@@ -1,0 +1,10 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from nagini_contracts.contracts import *
+
+
+def some_int() -> int:
+    #:: ExpectedOutput(invalid.program:incorrect.declared.type)
+    Ensures(ResultT(str) is None)
+    return 4

--- a/tests/functional/verification/test_adt_1.py
+++ b/tests/functional/verification/test_adt_1.py
@@ -72,7 +72,7 @@ def constructor_instance_2(l: LinkedList) -> None:
 def deconstructor_in_contract_1(l: Node) -> int:
     Requires(isinstance(l.elem, int))
     Requires(l.elem == 5)
-    Ensures(Result() == 10)
+    Ensures(ResultT(int) == 10)
     return l.elem * 2
 
 def deconstructor_in_constract_2(l: LinkedList) -> int:

--- a/tests/functional/verification/test_conversion.py
+++ b/tests/functional/verification/test_conversion.py
@@ -15,7 +15,7 @@ class Sub(Super):
 @Pure
 def test_ifexp(a: int) -> int:
     Ensures(Implies(a == 0, Result() == 66))
-    Ensures(Implies(a != 0, Result() == 55))
+    Ensures(Implies(a != 0, ResultT(int) == 55))
     return 55 if a else 66
 
 

--- a/tests/functional/verification/test_list_comprehension.py
+++ b/tests/functional/verification/test_list_comprehension.py
@@ -8,7 +8,7 @@ from typing import Generic, TypeVar, List, Tuple
 def m(l: List[int]) -> List[bool]:
     Requires(Acc(list_pred(l)))
     Ensures(Acc(list_pred(l)))
-    Ensures(Acc(list_pred(Result())))
+    Ensures(Acc(list_pred(ResultT(List[bool]))))
     Ensures(len(Result()) == len(l))
     Ensures(Forall(int, lambda i: (
     Implies(i >= 0 and i < len(Result()), Result()[i] == (l[i] != 5)), [[l[i]]])))

--- a/tests/functional/verification/test_tuples.py
+++ b/tests/functional/verification/test_tuples.py
@@ -7,7 +7,7 @@ from typing import Tuple, Union, cast
 
 def something(s: str, a: Tuple[str, int]) -> Tuple[str, str, int]:
     Requires(a[1] > 8)
-    Ensures(ResultT(Tuple[str, str, int])[1] == 'asd')
+    Ensures(Result()[1] == 'asd')
     Ensures(Result()[2] == a[1])
     Ensures(Result()[2] > 6)
     c = s + 'asdasd'

--- a/tests/functional/verification/test_tuples.py
+++ b/tests/functional/verification/test_tuples.py
@@ -7,7 +7,7 @@ from typing import Tuple, Union, cast
 
 def something(s: str, a: Tuple[str, int]) -> Tuple[str, str, int]:
     Requires(a[1] > 8)
-    Ensures(Result()[1] == 'asd')
+    Ensures(ResultT(Tuple[str, str, int])[1] == 'asd')
     Ensures(Result()[2] == a[1])
     Ensures(Result()[2] > 6)
     c = s + 'asdasd'

--- a/tests/functional/verification/test_unary_operator.py
+++ b/tests/functional/verification/test_unary_operator.py
@@ -46,7 +46,7 @@ class Test():
 
   def __pos__(self) -> 'Test':
     Requires(Acc(self.a, 1/2))
-    Ensures(Acc(self.a, 1/2) and Acc(Result().a))
+    Ensures(Acc(self.a, 1/2) and Acc(ResultT(Test).a))
     Ensures(Result().a == self.a)
     return Test(self.a)
 


### PR DESCRIPTION
Adding contract function ``ResultT(t)``, where t is a type literal that must coincide with the type of the current function, as an alias for ``Result()``.
Its purpose is to avoid problems with ``Any`` types in postconditions that use ``Result()`` (like in #204).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/205)
<!-- Reviewable:end -->
