### PR TITLE
Support for bitwise operations on bools and ints

### DIFF
--- a/src/nagini_translation/main.py
+++ b/src/nagini_translation/main.py
@@ -90,11 +90,12 @@ def parse_sil_file(sil_path: str, bv_path: str, bv_size: int, jvm, float_option:
 
 def load_sil_files(jvm: JVM, bv_size: int, sif: bool = False, float_option: str = None):
     current_path = os.path.dirname(inspect.stack()[0][1])
+    default_path = os.path.join(current_path, 'resources')
     if sif:
         resources_path = os.path.join(current_path, 'sif', 'resources')
     else:
-        resources_path = os.path.join(current_path, 'resources')
-    return parse_sil_file(os.path.join(resources_path, 'all.sil'), os.path.join(resources_path, 'intbv.sil'), bv_size, jvm, float_option)
+        resources_path = default_path
+    return parse_sil_file(os.path.join(resources_path, 'all.sil'), os.path.join(default_path, 'intbv.sil'), bv_size, jvm, float_option)
 
 
 def translate(path: str, jvm: JVM, bv_size: int, selected: Set[str] = set(), base_dir: str = None,

--- a/src/nagini_translation/resources/bool.sil
+++ b/src/nagini_translation/resources/bool.sil
@@ -24,6 +24,99 @@ function bool___bool__(self: Ref) : Bool
     ensures self == null ==> !result
     ensures self != null ==> result == bool___unbox__(self)
 
+function bool___and__(self: Bool, other: Bool): Bool
+    decreases _
+{ self && other }
+
+function bool___or__(self: Bool, other: Bool): Bool
+    decreases _
+{ self || other }
+
+function bool___xor__(self: Bool, other: Bool): Bool
+    decreases _
+{ self != other }
+
+function int___and__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+    ensures issubtype(typeof(result), int())
+    ensures result == int___and__(other, self)
+    ensures result ==
+    ((issubtype(typeof(self), bool()) && issubtype(typeof(other), bool())) ?
+        __prim__bool___box__(bool___unbox__(self) && bool___unbox__(other)) :
+        __prim__int___box__(fromBVInt(andBVInt(toBVInt(int___unbox__(self)), toBVInt(int___unbox__(other))))))
+
+function int___rand__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+{
+    int___and__(self, other)
+}
+
+function int___or__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+    ensures issubtype(typeof(result), int())
+    ensures result == int___or__(other, self)
+    ensures result ==
+    ((issubtype(typeof(self), bool()) && issubtype(typeof(other), bool())) ?
+        __prim__bool___box__(bool___unbox__(self) || bool___unbox__(other)) :
+        __prim__int___box__(fromBVInt(orBVInt(toBVInt(int___unbox__(self)), toBVInt(int___unbox__(other))))))
+
+function int___ror__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+{
+    int___or__(self, other)
+}
+
+function int___xor__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+    ensures issubtype(typeof(result), int())
+    ensures result == int___xor__(other, self)
+    ensures result ==
+    ((issubtype(typeof(self), bool()) && issubtype(typeof(other), bool())) ?
+        __prim__bool___box__(bool___unbox__(self) != bool___unbox__(other)) :
+        __prim__int___box__(fromBVInt(xorBVInt(toBVInt(int___unbox__(self)), toBVInt(int___unbox__(other))))))
+
+function int___rxor__(self: Ref, other: Ref): Ref
+    decreases _
+    requires issubtype(typeof(self), int())
+    requires issubtype(typeof(other), int())
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(self), bool()) ==> int___unbox__(self) <= _INT_MAX)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) >= _INT_MIN)
+    requires @error("Bitwise operations on ints can only be performed in the range set by the --int-bitops-size setting (default: 8 bits).")(!issubtype(typeof(other), bool()) ==> int___unbox__(other) <= _INT_MAX)
+{
+    int___xor__(self, other)
+}
+
 function int___bool__(self: Ref) : Bool
     decreases _
     requires self != null ==> issubtype(typeof(self), int())

--- a/src/nagini_translation/resources/intbv.sil
+++ b/src/nagini_translation/resources/intbv.sil
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024 ETH Zurich
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// File template: NBITS is to be replaced by the number of bits, INT_MAX_VAL and INT_MIN_VAL by the actual values.
+
+define _INT_MAX (INT_MAX_VAL)
+define _INT_MIN (INT_MIN_VAL)
+
+domain ___intbv interpretation (SMTLIB: "(_ BitVec NBITS)", Boogie: "bvNBITS") {
+  function toBVInt(i: Int): ___intbv interpretation "(_ int2bv NBITS)"
+  function fromBVInt(___intbv): Int interpretation "bv2int"
+  function andBVInt(___intbv, ___intbv): ___intbv interpretation "bvand"
+  function orBVInt(___intbv, ___intbv): ___intbv interpretation "bvor"
+  function xorBVInt(___intbv, ___intbv): ___intbv interpretation "bvxor"
+}

--- a/src/nagini_translation/resources/preamble.index
+++ b/src/nagini_translation/resources/preamble.index
@@ -290,6 +290,36 @@
             "args": ["int"],
             "type": "int",
             "requires": ["__prim__int___box__", "int___unbox__"]
+        },
+        "__and__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__prim__int___box__", "int___unbox__", "__prim__bool___box__", "bool___unbox__"]
+        },
+        "__rand__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__and__"]
+        },
+        "__or__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__prim__int___box__", "int___unbox__", "__prim__bool___box__", "bool___unbox__"]
+        },
+        "__ror__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__and__"]
+        },
+        "__xor__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__prim__int___box__", "int___unbox__", "__prim__bool___box__", "bool___unbox__"]
+        },
+        "__rxor__": {
+            "args": ["int", "int"],
+            "type": "int",
+            "requires": ["__and__"]
         }
     },
     "extends": "float"
@@ -434,6 +464,18 @@
             "args": ["bool", "object"],
             "type": "__prim__bool",
             "requires": ["__unbox__"]
+        },
+        "__and__": {
+            "args": ["__prim__bool", "__prim__bool"],
+            "type": "__prim__bool"
+        },
+        "__or__": {
+            "args": ["__prim__bool", "__prim__bool"],
+            "type": "__prim__bool"
+        },
+        "__xor__": {
+            "args": ["__prim__bool", "__prim__bool"],
+            "type": "__prim__bool"
         }
     },
     "extends": "int"

--- a/src/nagini_translation/tests.py
+++ b/src/nagini_translation/tests.py
@@ -569,7 +569,7 @@ class VerificationTest(AnnotatedTest):
             pytest.skip('Ignored')
         abspath = os.path.abspath(path)
         absbase = os.path.abspath(base)
-        modules, prog = translate(abspath, jvm, base_dir=absbase, sif=sif, arp=arp, reload_resources=reload_resources,
+        modules, prog = translate(abspath, jvm, 8, base_dir=absbase, sif=sif, arp=arp, reload_resources=reload_resources,
                                   float_encoding=float_encoding)
         assert prog is not None
         if store_viper:
@@ -638,7 +638,7 @@ class TranslationTest(AnnotatedTest):
         path = os.path.abspath(path)
         base = os.path.abspath(base)
         try:
-            translate(path, jvm, base_dir=base, sif=sif, arp=arp, reload_resources=reload_resources,
+            translate(path, jvm, 8, base_dir=base, sif=sif, arp=arp, reload_resources=reload_resources,
                       float_encoding=float_encoding)
             actual_errors = []
         except InvalidProgramException as exp1:

--- a/src/nagini_translation/translators/expression.py
+++ b/src/nagini_translation/translators/expression.py
@@ -27,7 +27,6 @@ from nagini_translation.lib.constants import (
     RIGHT_OPERATOR_FUNCTIONS,
     PRIMITIVE_INT_TYPE,
     PRIMITIVE_PERM_TYPE,
-    PRIMITIVE_BOOL_TYPE,
     SET_TYPE,
     STRING_TYPE,
     THREAD_DOMAIN,
@@ -987,6 +986,7 @@ class ExpressionTranslator(CommonTranslator):
         """
         position = self.to_position(node, ctx)
         stmt = []
+
         if self._is_primitive_operation(node.op, left_type, right_type):
             result = self._translate_primitive_operation(left, right, left_type,
                                                          node.op, position, ctx)

--- a/tests/functional/verification/float_ieee32/test_float.py
+++ b/tests/functional/verification/float_ieee32/test_float.py
@@ -28,6 +28,14 @@ def specialVals() -> None:
 def cmpLits() -> None:
     Assert(3.0 > 2.0)
     Assert(1.0 <= 40.0)
+    #:: ExpectedOutput(assert.failed:assertion.false)
+    Assert(44.0 < 10.2)
+
+def cmpLitsNeg() -> None:
+    Assert(-3.0 < 2.0)
+    Assert(-1.0 >= -40.0)
+    #:: ExpectedOutput(assert.failed:assertion.false)
+    Assert(8345.3454 < -2323.15345)
 
 def divSave(f: float, g: float) -> None:
     #:: ExpectedOutput(application.precondition:assertion.false)

--- a/tests/functional/verification/test_bitwise_op.py
+++ b/tests/functional/verification/test_bitwise_op.py
@@ -140,7 +140,7 @@ def or_4(a: int, b: bool, c: int) -> None:
 
 def xor_3(a: int, b: bool, c: int) -> None:
     Requires(a > -100 and a < 100)
-    Requires(c > -128 and c < 127)
+    Requires(c >= -128 and c <= 127)
     intbool = a ^ b
     boolint = b ^ a
     intint = a ^ c
@@ -159,7 +159,7 @@ def xor_3(a: int, b: bool, c: int) -> None:
 
 def xor_3a(a: int, b: bool, c: int) -> None:
     Requires(a > -100 and a < 100)
-    Requires(c > -128 and c < 127)
+    Requires(c >= -128 and c <= 127)
     intbool = a ^ b
     boolint = b ^ a
     if a == 5:
@@ -169,6 +169,6 @@ def xor_3a(a: int, b: bool, c: int) -> None:
 
 def xor_4(a: int, b: bool, c: int) -> None:
     Requires(a > -100 and a < 100)
-    Requires(c > -130 and c < 127)
+    Requires(c >= -128 and c < 129)
     #:: ExpectedOutput(application.precondition:assertion.false)
     intint = a ^ c

--- a/tests/functional/verification/test_bitwise_op.py
+++ b/tests/functional/verification/test_bitwise_op.py
@@ -1,0 +1,174 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from nagini_contracts.contracts import *
+from typing import cast
+
+
+
+def and_1(a: bool, b: bool, c: object) -> None:
+    anded = a & b
+    Assert(anded == b & a)
+    if not a:
+        Assert(not anded)
+    if anded:
+        Assert(b)
+    if isinstance(c, bool):
+        other = cast(bool, c) & a
+        if other:
+            Assert(cast(bool, c))
+
+def and_2(a: bool, b: bool, c: object) -> None:
+    anded = a & b
+    if not anded:
+        Assert(not a or not b)
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(not a)
+
+
+def or_1(a: bool, b: bool, c: object) -> None:
+    ored = a | b
+    Assert(ored == b | a)
+    if a:
+        Assert(ored)
+    if not ored:
+        Assert(not b)
+    if isinstance(c, bool):
+        other = cast(bool, c) | a
+        if not other:
+            Assert(not cast(bool, c))
+
+
+def or_2(a: bool, b: bool, c: object) -> None:
+    ored = a | b
+    if ored:
+        Assert(not (not a and not b))
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(a)
+
+
+def xor_1(a: bool, b: bool, c: object) -> None:
+    xored = a ^ b
+    Assert(xored == b ^ a)
+    if not a:
+        Assert(xored or not b)
+    if xored and a:
+        Assert(not b)
+    if isinstance(c, bool):
+        other = cast(bool, c) ^ a
+        if other ^ a:
+            Assert(cast(bool, c))
+
+def xor_2(a: bool, b: bool, c: object) -> None:
+    xored = a ^ b
+    if not xored:
+        Assert(a == b)
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(a and b)
+
+
+def and_3(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a & b
+    boolint = b & a
+    intint = a & c
+    Assert(intbool == boolint)
+    if isinstance(a, bool):
+        Assert(intbool == (cast(bool, a) and b))
+    if a == 3:
+        if c == 17:
+            Assert(intint == 1)
+        if c == 19:
+            Assert(intint == 3)
+        if c == 16:
+            #:: ExpectedOutput(assert.failed:assertion.false)
+            Assert(intint == 1)
+
+def and_3a(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a & b
+    boolint = b & a
+    if a == 5:
+        Assert(intbool == (1 if b else 0))
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(intbool == 1)
+
+def and_4(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -130 and c < 127)
+    #:: ExpectedOutput(application.precondition:assertion.false)
+    intint = a & c
+
+
+def or_3(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a | b
+    boolint = b | a
+    intint = a | c
+    Assert(intbool == boolint)
+    if isinstance(a, bool):
+        Assert(intbool == (cast(bool, a) or b))
+
+    if a == 3:
+        if c == 17:
+            Assert(intint == 19)
+        if c == 19:
+            Assert(intint == 19)
+        if c == 16:
+            #:: ExpectedOutput(assert.failed:assertion.false)
+            Assert(intint == 1)
+
+def or_3a(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a | b
+    boolint = b | a
+    if a == 4:
+        Assert(intbool == (5 if b else 4))
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(intbool == 5)
+
+def or_4(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -130 and c < 127)
+    #:: ExpectedOutput(application.precondition:assertion.false)
+    intint = a | c
+
+
+def xor_3(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a ^ b
+    boolint = b ^ a
+    intint = a ^ c
+    Assert(intbool == boolint)
+    if isinstance(a, bool):
+        Assert(intbool == (cast(bool, a) != b))
+
+    if a == 3:
+        if c == 17:
+            Assert(intint == 18)
+        if c == 19:
+            Assert(intint == 16)
+        if c == 16:
+            #:: ExpectedOutput(assert.failed:assertion.false)
+            Assert(intint == 16)
+
+def xor_3a(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -128 and c < 127)
+    intbool = a ^ b
+    boolint = b ^ a
+    if a == 5:
+        Assert(intbool == (4 if b else 5))
+        #:: ExpectedOutput(assert.failed:assertion.false)
+        Assert(intbool == 5)
+
+def xor_4(a: int, b: bool, c: int) -> None:
+    Requires(a > -100 and a < 100)
+    Requires(c > -130 and c < 127)
+    #:: ExpectedOutput(application.precondition:assertion.false)
+    intint = a ^ c


### PR DESCRIPTION
Adds support for ``e1 & e2``, ``e1 | e2`` and ``e1 ^ e2``, where both expressions can be either bools or integers.

We use the SMT bitvector theory for the encoding. That theory unfortunately only supports fixed-size bitvectors, which cannot represent Python's arbitrarily large integers. Additionally, for large bitvectors, things get really really slow.
So, as a compromise, we require that all integers on which bitwise operations are performed are inside some fixed range.

To set this range, there is a new command line parameter ``--int-bitops-size``, whose default value is 8 (so 8-bit signed integers). That's obviously a very small default value, but things are realllly slow with something like 32 bits, and in the interest of having terminating tests, we use this small default, and clients can choose something larger if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/208)
<!-- Reviewable:end -->
