### PR TITLE
Postconditions with lambdas

### DIFF
--- a/src/nagini_contracts/contracts.py
+++ b/src/nagini_contracts/contracts.py
@@ -14,6 +14,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    overload,
     Sized,
     Tuple,
     Type,
@@ -44,8 +45,12 @@ U4 = TypeVar('U4')
 def Requires(expr: bool) -> bool:
     pass
 
-
+@overload
 def Ensures(expr: bool) -> bool:
+    pass
+
+@overload
+def Ensures(t: Type[T], expr: Callable[[T], bool]) -> bool:
     pass
 
 

--- a/src/nagini_translation/analyzer.py
+++ b/src/nagini_translation/analyzer.py
@@ -935,8 +935,22 @@ class Analyzer(ast.NodeVisitor):
                 self.stmt_container.precondition.append(
                     (node.args[0], self._aliases.copy()))
             elif node.func.id == 'Ensures':
-                self.stmt_container.postcondition.append(
-                    (node.args[0], self._aliases.copy()))
+                if len(node.args) > 1:
+                    res_type = self.get_target(node.args[0], self.stmt_container)
+                    if self.current_function.type is None:
+                        raise InvalidProgramException(node, 'invalid.result')
+                    expected_type_name = self.current_function.type.python_class.name
+                    declared_type_name = res_type.name
+                    if expected_type_name != declared_type_name:
+                        raise InvalidProgramException(node, 'invalid.result.type')
+                    assert isinstance(node.args[1], ast.Lambda)
+                    if len(node.args[1].args.args) != 1:
+                        raise InvalidProgramException(node, 'invalid.result.type')
+                    self.stmt_container.postcondition.append(
+                        (node.args[1], self._aliases.copy()))
+                else:
+                    self.stmt_container.postcondition.append(
+                        (node.args[0], self._aliases.copy()))
             elif node.func.id == 'Decreases':
                 if not (isinstance(self.stmt_container, PythonMethod) and self.stmt_container.pure):
                     raise InvalidProgramException(node, 'invalid.contract.position')

--- a/src/nagini_translation/translators/expression.py
+++ b/src/nagini_translation/translators/expression.py
@@ -685,6 +685,10 @@ class ExpressionTranslator(CommonTranslator):
                     not isinstance(node.ctx, ast.Store) and
                     self.is_local_variable(var, ctx)):
                 result = self.wrap_definedness_check(var.ref(node, ctx), var, node, ctx)
+            elif var is ctx.actual_function.result and ctx.actual_function.pure:
+                pos = self.to_position(node, ctx)
+                info = self.no_info(ctx)
+                result = self.viper.Result(self.translate_type(ctx.actual_function.result.type, ctx), pos, info)
             else:
                 result = var.ref(node, ctx)
             return [], result

--- a/src/nagini_translation/translators/method.py
+++ b/src/nagini_translation/translators/method.py
@@ -140,7 +140,14 @@ class MethodTranslator(CommonTranslator):
                                     self.no_position(ctx), self.no_info(ctx))
         for post, aliases in method.postcondition:
             with ctx.additional_aliases(aliases):
-                stmt, expr = self.translate_expr(post, ctx, self.viper.Bool, True)
+                if isinstance(post, ast.Lambda):
+                    res_name = post.args.args[0].arg
+                    res_var = ctx.current_function.result
+                    res_aliases = {res_name: res_var}
+                    with ctx.additional_aliases(res_aliases):
+                        stmt, expr = self.translate_expr(post.body, ctx, self.viper.Bool, True)
+                else:
+                    stmt, expr = self.translate_expr(post, ctx, self.viper.Bool, True)
             if stmt:
                 raise InvalidProgramException(post, 'purity.violated')
             if method.declared_exceptions:
@@ -298,7 +305,14 @@ class MethodTranslator(CommonTranslator):
         posts = []
         for post, aliases in func.postcondition:
             with ctx.additional_aliases(aliases):
-                stmt, expr = self.translate_expr(post, ctx, self.viper.Bool)
+                if isinstance(post, ast.Lambda):
+                    res_name = post.args.args[0].arg
+                    res_var = ctx.current_function.result
+                    res_aliases = {res_name: res_var}
+                    with ctx.additional_aliases(res_aliases):
+                        stmt, expr = self.translate_expr(post.body, ctx, self.viper.Bool, True)
+                else:
+                    stmt, expr = self.translate_expr(post, ctx, self.viper.Bool)
             if stmt:
                 raise InvalidProgramException(post, 'purity.violated')
             posts.append(expr)

--- a/tests/functional/translation/test_result_3.py
+++ b/tests/functional/translation/test_result_3.py
@@ -1,0 +1,10 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from nagini_contracts.contracts import *
+
+
+def noreturn() -> None:
+    #:: ExpectedOutput(invalid.program:invalid.result)
+    Ensures(int, lambda i: i is None)
+    pass

--- a/tests/functional/translation/test_result_4.py
+++ b/tests/functional/translation/test_result_4.py
@@ -1,0 +1,10 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+from nagini_contracts.contracts import *
+
+
+def noreturn() -> bool:
+    #:: ExpectedOutput(invalid.program:invalid.result.type)
+    Ensures(int, lambda i: i is None)
+    return True

--- a/tests/functional/verification/test_post_lambda.py
+++ b/tests/functional/verification/test_post_lambda.py
@@ -1,0 +1,40 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+
+from typing import Tuple
+
+from nagini_contracts.contracts import Ensures, Requires, Result, Pure
+
+
+def huh(t: Tuple[int, bool, int], i: int) -> int:
+  Requires(0 <= i and i < 3)
+  #:: ExpectedOutput(postcondition.violated:assertion.false)
+  Ensures(int, lambda r: r >= 5)
+  j: int = t[2]
+  return j + 5
+
+
+def huh2(t: Tuple[int, bool, int], i: int) -> int:
+  Requires(0 <= i and i < 3)
+  Requires(t[0] >= 0 and t[2] >= 0)
+  Ensures(int, lambda r: r >= 5)
+  j: int = t[1]
+  k: bool = t[0] == 34
+  return j + 5
+
+@Pure
+def huh3(t: Tuple[int, bool, int], i: int) -> int:
+  Requires(0 <= i and i < 3)
+  Requires(t[0] >= 0 and t[2] >= 0)
+  Ensures(int, lambda r: r >= 5)
+  j: int = t[2]
+  return j + 5
+
+@Pure
+def huh4(t: Tuple[int, bool, int], i: int) -> int:
+  Requires(0 <= i and i < 3)
+  #:: ExpectedOutput(postcondition.violated:assertion.false)
+  Ensures(int, lambda r: r >= 5)
+  j: int = t[2]
+  return j + 5


### PR DESCRIPTION
Introduces ``Ensures(T, lambda r: P(r)`` as an alternative to ``Ensures(P(Result()))`` for the postcondition of a function or method with return type ``T``. This has the advantage that it can be fully type-checked by mypy, since there is no Any-typed ``Result()`` in the postcondition, and it can be executed without getting a runtime error.