### PR TITLE
Use obligation encoding only when needed

### DIFF
--- a/src/nagini_translation/analyzer.py
+++ b/src/nagini_translation/analyzer.py
@@ -14,7 +14,12 @@ import tokenize
 
 from collections import OrderedDict
 from nagini_contracts.contracts import CONTRACT_FUNCS, CONTRACT_WRAPPER_FUNCS
-from nagini_contracts.io_contracts import IO_OPERATION_PROPERTY_FUNCS
+from nagini_contracts.io_contracts import (
+    BUILTIN_IO_OPERATIONS,
+    IO_CONTRACT_FUNCS,
+    IO_OPERATION_PROPERTY_FUNCS
+)
+from nagini_contracts.obligations import OBLIGATION_CONTRACT_FUNCS
 from nagini_translation.analyzer_io import IOOperationAnalyzer
 from nagini_translation.external.ast_util import mark_text_ranges
 from nagini_translation.lib.constants import (
@@ -95,6 +100,7 @@ class Analyzer(ast.NodeVisitor):
         self.selected = selected
         self.deferred_tasks = []
         self.has_all_low = False
+        self.enable_obligations = False
 
     def initialize_io_analyzer(self) -> None:
         self.io_operation_analyzer = IOOperationAnalyzer(
@@ -957,6 +963,8 @@ class Analyzer(ast.NodeVisitor):
             node.func.id in IO_OPERATION_PROPERTY_FUNCS):
             raise InvalidProgramException(
                 node, 'invalid.io_operation.misplaced_property')
+        if self._requires_obligations(node.func):
+            self.enable_obligations = True
         if isinstance(node.func, ast.Name) and node.func.id == 'Thread':
             return
         if isinstance(node.func, ast.Name) and node.func.id == 'getOld':
@@ -971,6 +979,34 @@ class Analyzer(ast.NodeVisitor):
             if contains_stmt(preconditions, node) or contains_stmt(postconditions, node):
                 raise InvalidProgramException(node, 'invalid.contract.position')
         self.visit_default(node)
+
+    def _requires_obligations(self, node: ast.AST) -> bool:
+        """
+        Conservatively checks if the given node, representing a called function, may require the use of obligations.
+        """
+        if isinstance(node, ast.Name):
+            return (node.id in OBLIGATION_CONTRACT_FUNCS or
+                    node.id in BUILTIN_IO_OPERATIONS or
+                    node.id in IO_CONTRACT_FUNCS)
+        elif isinstance(node, ast.Attribute):
+            try:
+                recv_type = self.typeof(node.value)
+            except:
+                # type computation is not implemented fully here, so this may fail
+                recv_type = None
+            if node.attr in ('start', 'join') and (recv_type is None or recv_type.python_class.name == 'Thread'):
+                # Thread operations interact with obligations
+                return True
+            elif node.attr in ('release', 'acquire'):
+                # Lock operations interact with obligations
+                if recv_type is None:
+                    return True
+                while recv_type is not None:
+                    if recv_type.python_class.name == 'Lock':
+                        return True
+                    recv_type = recv_type.superclass
+                return False
+        return False
 
     def _get_parent_of_type(self, node: ast.AST, typ: type) -> ast.AST:
         """
@@ -1397,6 +1433,8 @@ class Analyzer(ast.NodeVisitor):
                     raise UnsupportedException(node)
             elif node.func.id == 'cast':
                 return self.find_or_create_target_class(node.args[0])
+            elif node.func.id == 'super':
+                return self.current_class.superclass  ## TODO: constructor call
             else:
                 f = self.module.get_func_or_method(node.func.id)
                 if f is not None:

--- a/src/nagini_translation/analyzer.py
+++ b/src/nagini_translation/analyzer.py
@@ -1434,7 +1434,7 @@ class Analyzer(ast.NodeVisitor):
             elif node.func.id == 'cast':
                 return self.find_or_create_target_class(node.args[0])
             elif node.func.id == 'super':
-                return self.current_class.superclass  ## TODO: constructor call
+                return self.current_class.superclass
             else:
                 f = self.module.get_func_or_method(node.func.id)
                 if f is not None:

--- a/src/nagini_translation/analyzer_io.py
+++ b/src/nagini_translation/analyzer_io.py
@@ -64,6 +64,7 @@ class IOOperationAnalyzer(ast.NodeVisitor):
         Creates non-initialized IO operation from an AST node and adds
         it to the module.
         """
+        self._parent._enable_obligations = True
         name = node.name
         assert isinstance(name, str)
         operation = self._node_factory.create_python_io_operation(

--- a/src/nagini_translation/conftest.py
+++ b/src/nagini_translation/conftest.py
@@ -282,7 +282,8 @@ def pytest_generate_tests(metafunc: 'pytest.python.Metafunc'):
             float_encoding = new_float_encoding
             arp = 'arp' in file
             base = file.partition('verification')[0] + 'verification'
-            params.extend([(file, base, verifier, sif, reload_resources, arp, ignore_obligations,
+            params.extend([(file, base, verifier, sif, reload_resources, arp,
+                            ignore_obligations or (None if verifier == 'silicon' else False),
                             _pytest_config.store_viper, float_encoding) for verifier
                            in _pytest_config.verifiers])
         metafunc.parametrize('path,base,verifier,sif,reload_resources,arp,ignore_obligations,print,float_encoding', params)

--- a/src/nagini_translation/lib/config.py
+++ b/src/nagini_translation/lib/config.py
@@ -46,7 +46,7 @@ class ObligationConfig(SectionConfig):
     @property
     def disable_all(self):
         """Disable all obligation related checks."""
-        return self._info.getboolean('disable_all', False)
+        return self._info.getboolean('disable_all', None)
 
     @disable_all.setter
     def disable_all(self, val):

--- a/src/nagini_translation/main.py
+++ b/src/nagini_translation/main.py
@@ -145,6 +145,7 @@ def translate(path: str, jvm: JVM, bv_size: int, selected: Set[str] = set(), bas
         translator = Translator(jvm, path, types, viper_ast)
     analyzer.process(translator)
     if not analyzer.enable_obligations and config.obligation_config.disable_all is None:
+        # only override the default, which is None; if the encoding is forced on or off, it'll be True or False
         config.obligation_config.disable_all = True
     if 'sil_programs' not in globals() or reload_resources:
         global sil_programs
@@ -367,7 +368,7 @@ def main() -> None:
             parser.error('incompatible arguments: --ignore-obligations and --force-obligations')
         config.obligation_config.disable_all = True
     elif args.force_obligations:
-        config.obligation_config.disable_all = False
+        config.obligation_config.disable_all = False  # False instead of None: force obligation encoding
 
     if not config.classpath:
         parser.error('missing argument: --viper-jar-path')

--- a/src/nagini_translation/main.py
+++ b/src/nagini_translation/main.py
@@ -144,6 +144,8 @@ def translate(path: str, jvm: JVM, bv_size: int, selected: Set[str] = set(), bas
     else:
         translator = Translator(jvm, path, types, viper_ast)
     analyzer.process(translator)
+    if not analyzer.enable_obligations:
+        config.obligation_config.disable_all = True
     if 'sil_programs' not in globals() or reload_resources:
         global sil_programs
         sil_programs = load_sil_files(jvm, bv_size, sif, float_encoding)


### PR DESCRIPTION
Changes Nagini's default behavior s.t. the obligation encoding is used only when it may actually be needed, i.e., when thread or lock operations are used, IO operations are used or defined, or any obligation-related specification is used in the program.

A new command line flag ``--force-obligations`` forces the use of the encoding.
The test setup is modified s.t. Carbon tests are run with the obligation encoding forced on, whereas Silicon tests use it only when it's needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/230)
<!-- Reviewable:end -->
