### PR TITLE
Removing dependency to specific setuptools version, adding it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install Nagini
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools==68.2.0
         pip install .
     - name: Test with pytest
       run: |

--- a/.github/workflows/testWin.yml
+++ b/.github/workflows/testWin.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Install Nagini
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools==68.2.0
         pip install pytest
         pip install .
     - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
             'astunparse==1.6.2',
             'pytest==4.3.0',
             'z3-solver==4.8.7.0',
-            'setuptools==68.2.0'
             ],
         entry_points={
              'console_scripts': [


### PR DESCRIPTION
- We need this setuptools version in the CI to make things run smoothly for some reason
- It's not needed in general though, and there is a security issue with this version, so it's better not to require it in setup.py

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/253)
<!-- Reviewable:end -->
