### PR TITLE
Proper output for translation errors in IDE mode

### DIFF
--- a/src/nagini_translation/lib/errors/__init__.py
+++ b/src/nagini_translation/lib/errors/__init__.py
@@ -16,3 +16,4 @@ This includes:
 
 from nagini_translation.lib.errors.manager import manager as error_manager
 from nagini_translation.lib.errors.rules import Rules
+from nagini_translation.lib.errors.wrappers import format_translation_error

--- a/src/nagini_translation/lib/errors/wrappers.py
+++ b/src/nagini_translation/lib/errors/wrappers.py
@@ -14,6 +14,29 @@ from nagini_translation.lib.errors.messages import ERRORS, REASONS, VAGUE_REASON
 from nagini_translation.lib.errors.rules import Rules
 
 
+def format_translation_error(ide_mode: bool, file: str, message: str,
+                             line: int, col: int, line_end: int = None,
+                             col_end: int = None) -> str:
+    """Format a translation error (invalid program, unsupported, type error).
+
+    In IDE mode this mirrors the layout produced for verification errors by
+    :meth:`Error.string` (``file:line:col:line_end:col_end: error: message``),
+    so an IDE/LSP frontend can parse translation and verification errors
+    uniformly. ``line`` is 1-based and ``col`` is a 0-based column (the Python
+    AST ``col_offset`` convention, which is also what Nagini stores in Viper
+    positions); IDE mode emits ``col + 1`` to match the columns Viper reports.
+    Without IDE mode the human-readable ``message (file@line.col)`` form is kept.
+    """
+    if ide_mode:
+        if line_end is None:
+            line_end = line
+        if col_end is None:
+            col_end = col
+        return '{0}:{1}:{2}:{3}:{4}: error: {5}'.format(
+            file, line, col + 1, line_end, col_end + 1, message)
+    return '{0} ({1}@{2}.{3})'.format(message, file, line, col)
+
+
 class Position:
     """Wrapper around ``AbstractSourcePosition``."""
 

--- a/src/nagini_translation/lib/typeinfo.py
+++ b/src/nagini_translation/lib/typeinfo.py
@@ -290,6 +290,12 @@ class TypeInfo:
         result = mypy.options.Options()
         result.strict_optional = strict_optional
         result.show_traceback = True
+        # Emit "file:line:col:end_line:end_col: error: msg" so that reported type
+        # errors carry a real source range (start and end) instead of only a
+        # line, matching the format Nagini produces for verification errors.
+        # show_error_end implies show_column_numbers.
+        result.show_column_numbers = True
+        result.show_error_end = True
         result.export_types = True
         result.preserve_asts = True
         result.warn_no_return = False

--- a/src/nagini_translation/main.py
+++ b/src/nagini_translation/main.py
@@ -22,7 +22,7 @@ from nagini_translation.analyzer import Analyzer
 from nagini_translation.sif_translator import SIFTranslator
 from nagini_translation.lib import config
 from nagini_translation.lib.constants import DEFAULT_SERVER_SOCKET
-from nagini_translation.lib.errors import error_manager
+from nagini_translation.lib.errors import error_manager, format_translation_error
 from nagini_translation.lib.jvmaccess import (
     getclass,
     getobject,
@@ -54,7 +54,15 @@ from nagini_translation import verifier
 from typing import List, Set, Tuple, Union
 
 
-TYPE_ERROR_PATTERN = r"^(?P<file>.*):(?P<line>\d+): error: (?P<msg>.*)$"
+# Matches a mypy error line. The column and end-position fields are optional:
+# mypy only emits them when show_column_numbers/show_error_end are set, and some
+# type errors Nagini raises itself carry only a line. The file group is
+# non-greedy so a Windows drive letter (``C:\...``) or a ``: error:`` inside the
+# message does not get mistaken for the line/column separators.
+TYPE_ERROR_PATTERN = (
+    r"^(?P<file>.*?):(?P<line>\d+)"
+    r"(?::(?P<col>\d+)(?::(?P<end_line>\d+):(?P<end_col>\d+))?)?"
+    r": error: (?P<msg>.*)$")
 TYPE_ERROR_MATCHER = re.compile(TYPE_ERROR_PATTERN)
 
 
@@ -486,9 +494,10 @@ def translate_and_verify(python_file, jvm, args, print=print, arp=False, base_di
                     issue += e.args[0]
                 else:
                     issue += ast.unparse(e.node)
-            line = str(e.node.lineno)
-            col = str(e.node.col_offset)
-            print(issue + ' (' + python_file + '@' + line + '.' + col + ')')
+            print(format_translation_error(
+                args.ide_mode, python_file, issue, e.node.lineno,
+                e.node.col_offset, getattr(e.node, 'end_lineno', None),
+                getattr(e.node, 'end_col_offset', None)))
         if isinstance(e, TypeException):
             for msg in e.messages:
                 parts = TYPE_ERROR_MATCHER.match(msg)
@@ -498,8 +507,17 @@ def translate_and_verify(python_file, jvm, args, print=print, arp=False, base_di
                     if file == '__main__':
                         file = python_file
                     msg = parts['msg']
-                    line = parts['line']
-                    print('Type error: ' + msg + ' (' + file + '@' + line + '.0)')
+                    line = int(parts['line'])
+                    # mypy reports a 1-based start column and an (exclusive) end
+                    # position when available; convert to the 0-based-column
+                    # convention format_translation_error expects. Fall back to
+                    # column 0 for errors Nagini raises itself (line only).
+                    col = int(parts['col']) - 1 if parts['col'] else 0
+                    line_end = int(parts['end_line']) if parts['end_line'] else None
+                    col_end = int(parts['end_col']) if parts['end_col'] else None
+                    print(format_translation_error(
+                        args.ide_mode, file, 'Type error: ' + msg, line, col,
+                        line_end, col_end))
                 else:
                     print(msg)
         return False


### PR DESCRIPTION
The ``--ide-mode`` command line option leads to error output in a fixed form that includes end lines and columns, like this:

```
Verification failed
Errors:
test_predicate_family_modularity.py:17:5:17:21: error: Fold might fail. Might not be able to satisfy constraints from currently unknown predicate family members.
test_predicate_family_modularity.py:23:5:24:47: error: Predicate state might not be well-formed. Predicate family addition might not be self-framing.
Verification took 9.41 seconds.
```

Currently, however, this formatting does not apply to translation errors, which look different:
```
Translation failed
Invalid program: abstract.predicate.fold (tests/functional/translation/test_abstract_pred_1.py@17.11)
```

This PR fixes that so that the ``--ide-mode`` flag applies to all errors:
```
Translation failed
tests/functional/translation/test_abstract_pred_1.py:17:12:17:33: error: Invalid program: abstract.predicate.fold
```

That also includes type errors, which requires setting an additional mypy flag:
```
Translation failed
testmcp.py:10:16:10:20: error: Type error: Incompatible return value type (got "int", expected "bool")  [return-value]
testmcp.py:12:16:12:19: error: Type error: Incompatible return value type (got "int", expected "bool")  [return-value]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/308)
<!-- Reviewable:end -->
