### PR TITLE
Expose viper args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build
 deps/JPype1
 __pycache__
 .virtualenv
+.venv
 .cache
 .installed.cfg
 .mr.developer.cfg

--- a/README.rst
+++ b/README.rst
@@ -188,9 +188,8 @@ structured diagnostics (error positions, messages, and optional counterexamples)
 The server exposes the following tools: ``verify_file``, ``verify_method``,
 ``verify_snippet``, ``configure`` (change verification options at runtime),
 ``cancel``, and ``flush_cache``. The verification tools also accept per-request
-options: extra Viper backend arguments (``viper_args``, e.g. a ``--timeout``),
-returning the translated Viper program (``include_viper``), and abstract read
-permissions (``arp``). See the
+options: extra Viper backend arguments (``viper_args``, e.g. a ``--timeout``)
+and returning the translated Viper program (``include_viper``). See the
 `wiki <https://github.com/marcoeilers/nagini/wiki>`_ for information on how to write
 specifications in Nagini.
 

--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,10 @@ structured diagnostics (error positions, messages, and optional counterexamples)
 
 The server exposes the following tools: ``verify_file``, ``verify_method``,
 ``verify_snippet``, ``configure`` (change verification options at runtime),
-``cancel``, and ``flush_cache``. See the
+``cancel``, and ``flush_cache``. The verification tools also accept per-request
+options: extra Viper backend arguments (``viper_args``, e.g. a ``--timeout``),
+an obligation-encoding override (``obligations``), dumping the translated Viper
+program (``write_viper_to_file``), and abstract read permissions (``arp``). See the
 `wiki <https://github.com/marcoeilers/nagini/wiki>`_ for information on how to write
 specifications in Nagini.
 

--- a/README.rst
+++ b/README.rst
@@ -189,8 +189,8 @@ The server exposes the following tools: ``verify_file``, ``verify_method``,
 ``verify_snippet``, ``configure`` (change verification options at runtime),
 ``cancel``, and ``flush_cache``. The verification tools also accept per-request
 options: extra Viper backend arguments (``viper_args``, e.g. a ``--timeout``),
-an obligation-encoding override (``obligations``), dumping the translated Viper
-program (``write_viper_to_file``), and abstract read permissions (``arp``). See the
+returning the translated Viper program (``include_viper``), and abstract read
+permissions (``arp``). See the
 `wiki <https://github.com/marcoeilers/nagini/wiki>`_ for information on how to write
 specifications in Nagini.
 

--- a/src/nagini_translation/mcp_server.py
+++ b/src/nagini_translation/mcp_server.py
@@ -87,7 +87,6 @@ async def verify_file(path: str, method: Optional[str] = None,
 
 @mcp.tool()
 async def verify_method(path: str, method: str, counterexample: bool = False,
-                        base_dir: Optional[str] = None,
                         viper_args: Optional[List[str]] = None,
                         include_viper: bool = False,
                         job_token: Optional[str] = None) -> dict:
@@ -100,8 +99,8 @@ async def verify_method(path: str, method: str, counterexample: bool = False,
     """
     result = await _run(lambda: _service.verify(
         path, selected={method}, counterexample=counterexample,
-        base_dir=base_dir, viper_args=viper_args,
-        include_viper=include_viper, job_token=job_token))
+        viper_args=viper_args, include_viper=include_viper,
+        job_token=job_token))
     return result.to_dict()
 
 

--- a/src/nagini_translation/mcp_server.py
+++ b/src/nagini_translation/mcp_server.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from typing import List, Optional
 
 from mcp.server.fastmcp import FastMCP
 
@@ -48,6 +48,10 @@ async def verify_file(path: str, method: Optional[str] = None,
                       counterexample: bool = False,
                       ignore_global: bool = False,
                       base_dir: Optional[str] = None,
+                      viper_args: Optional[List[str]] = None,
+                      obligations: Optional[str] = None,
+                      write_viper_to_file: Optional[str] = None,
+                      arp: bool = False,
                       job_token: Optional[str] = None) -> dict:
     """Verify a Nagini Python file.
 
@@ -68,36 +72,59 @@ async def verify_file(path: str, method: Optional[str] = None,
     resolve), and leave it unset for a standalone file. Pass a `job_token` to
     allow precisely cancelling this run via the `cancel` tool. Multiple
     verifications may run concurrently.
+
+    `viper_args` are extra command-line arguments passed to the Viper backend,
+    e.g. `["--timeout=60"]` for a per-run verification timeout in seconds (the
+    CLI's `--viper-arg`, as a list). `obligations` overrides the obligation
+    encoding for this request: 'force' enables it, 'ignore' disables it, and
+    'auto' (default) detects per program. `write_viper_to_file` writes the
+    translated Viper program to that path for debugging. Set `arp` to verify
+    under abstract read permissions (requires the ARP plugin on the classpath;
+    such requests run serially).
     """
     selected = {method} if method else None
     result = await _run(lambda: _service.verify(
         path, selected=selected, counterexample=counterexample, base_dir=base_dir,
-        ignore_global=ignore_global, job_token=job_token))
+        ignore_global=ignore_global, viper_args=viper_args,
+        obligations=obligations, write_viper_to_file=write_viper_to_file,
+        arp=arp, job_token=job_token))
     return result.to_dict()
 
 
 @mcp.tool()
 async def verify_method(path: str, method: str, counterexample: bool = False,
+                        base_dir: Optional[str] = None,
+                        viper_args: Optional[List[str]] = None,
+                        obligations: Optional[str] = None,
+                        write_viper_to_file: Optional[str] = None,
+                        arp: bool = False,
                         job_token: Optional[str] = None) -> dict:
     """Verify only a single method of a file (fast, via Nagini's --select).
 
     `path` should be absolute (see `verify_file`). `method` names a top-level
     function by its bare name (e.g. `my_func`), a method as `ClassName.method_name`
-    (its bare name also matches), or a whole class by `ClassName`.
+    (its bare name also matches), or a whole class by `ClassName`. The other
+    parameters are as in `verify_file`.
     """
     result = await _run(lambda: _service.verify(
         path, selected={method}, counterexample=counterexample,
-        job_token=job_token))
+        base_dir=base_dir, viper_args=viper_args, obligations=obligations,
+        write_viper_to_file=write_viper_to_file, arp=arp, job_token=job_token))
     return result.to_dict()
 
 
 @mcp.tool()
 async def verify_snippet(code: str, counterexample: bool = False,
                          ignore_global: bool = False,
+                         viper_args: Optional[List[str]] = None,
+                         obligations: Optional[str] = None,
+                         write_viper_to_file: Optional[str] = None,
+                         arp: bool = False,
                          job_token: Optional[str] = None) -> dict:
     """Verify an inline snippet of Nagini Python code (written to a temp file).
 
-    Set `ignore_global` to skip verification of top-level statements.
+    Set `ignore_global` to skip verification of top-level statements. The other
+    parameters are as in `verify_file`.
     """
     tmp_dir = tempfile.mkdtemp(prefix='nagini_mcp_')
     tmp_path = os.path.join(tmp_dir, 'snippet.py')
@@ -106,7 +133,9 @@ async def verify_snippet(code: str, counterexample: bool = False,
             f.write(code)
         result = await _run(lambda: _service.verify(
             tmp_path, counterexample=counterexample, base_dir=tmp_dir,
-            ignore_global=ignore_global, job_token=job_token))
+            ignore_global=ignore_global, viper_args=viper_args,
+            obligations=obligations, write_viper_to_file=write_viper_to_file,
+            arp=arp, job_token=job_token))
         return result.to_dict()
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/nagini_translation/mcp_server.py
+++ b/src/nagini_translation/mcp_server.py
@@ -49,8 +49,7 @@ async def verify_file(path: str, method: Optional[str] = None,
                       ignore_global: bool = False,
                       base_dir: Optional[str] = None,
                       viper_args: Optional[List[str]] = None,
-                      obligations: Optional[str] = None,
-                      write_viper_to_file: Optional[str] = None,
+                      include_viper: bool = False,
                       arp: bool = False,
                       job_token: Optional[str] = None) -> dict:
     """Verify a Nagini Python file.
@@ -75,19 +74,17 @@ async def verify_file(path: str, method: Optional[str] = None,
 
     `viper_args` are extra command-line arguments passed to the Viper backend,
     e.g. `["--timeout=60"]` for a per-run verification timeout in seconds (the
-    CLI's `--viper-arg`, as a list). `obligations` overrides the obligation
-    encoding for this request: 'force' enables it, 'ignore' disables it, and
-    'auto' (default) detects per program. `write_viper_to_file` writes the
-    translated Viper program to that path for debugging. Set `arp` to verify
-    under abstract read permissions (requires the ARP plugin on the classpath;
-    such requests run serially).
+    CLI's `--viper-arg`, as a list). `include_viper` returns the translated
+    Viper program in `viperProgram`; even a small file translates to hundreds
+    of lines, so only request it when needed. Set `arp` to verify under
+    abstract read permissions (requires the ARP plugin on the classpath; such
+    requests run serially).
     """
     selected = {method} if method else None
     result = await _run(lambda: _service.verify(
         path, selected=selected, counterexample=counterexample, base_dir=base_dir,
         ignore_global=ignore_global, viper_args=viper_args,
-        obligations=obligations, write_viper_to_file=write_viper_to_file,
-        arp=arp, job_token=job_token))
+        include_viper=include_viper, arp=arp, job_token=job_token))
     return result.to_dict()
 
 
@@ -95,8 +92,7 @@ async def verify_file(path: str, method: Optional[str] = None,
 async def verify_method(path: str, method: str, counterexample: bool = False,
                         base_dir: Optional[str] = None,
                         viper_args: Optional[List[str]] = None,
-                        obligations: Optional[str] = None,
-                        write_viper_to_file: Optional[str] = None,
+                        include_viper: bool = False,
                         arp: bool = False,
                         job_token: Optional[str] = None) -> dict:
     """Verify only a single method of a file (fast, via Nagini's --select).
@@ -108,8 +104,8 @@ async def verify_method(path: str, method: str, counterexample: bool = False,
     """
     result = await _run(lambda: _service.verify(
         path, selected={method}, counterexample=counterexample,
-        base_dir=base_dir, viper_args=viper_args, obligations=obligations,
-        write_viper_to_file=write_viper_to_file, arp=arp, job_token=job_token))
+        base_dir=base_dir, viper_args=viper_args,
+        include_viper=include_viper, arp=arp, job_token=job_token))
     return result.to_dict()
 
 
@@ -117,8 +113,7 @@ async def verify_method(path: str, method: str, counterexample: bool = False,
 async def verify_snippet(code: str, counterexample: bool = False,
                          ignore_global: bool = False,
                          viper_args: Optional[List[str]] = None,
-                         obligations: Optional[str] = None,
-                         write_viper_to_file: Optional[str] = None,
+                         include_viper: bool = False,
                          arp: bool = False,
                          job_token: Optional[str] = None) -> dict:
     """Verify an inline snippet of Nagini Python code (written to a temp file).
@@ -134,8 +129,7 @@ async def verify_snippet(code: str, counterexample: bool = False,
         result = await _run(lambda: _service.verify(
             tmp_path, counterexample=counterexample, base_dir=tmp_dir,
             ignore_global=ignore_global, viper_args=viper_args,
-            obligations=obligations, write_viper_to_file=write_viper_to_file,
-            arp=arp, job_token=job_token))
+            include_viper=include_viper, arp=arp, job_token=job_token))
         return result.to_dict()
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/nagini_translation/mcp_server.py
+++ b/src/nagini_translation/mcp_server.py
@@ -50,7 +50,6 @@ async def verify_file(path: str, method: Optional[str] = None,
                       base_dir: Optional[str] = None,
                       viper_args: Optional[List[str]] = None,
                       include_viper: bool = False,
-                      arp: bool = False,
                       job_token: Optional[str] = None) -> dict:
     """Verify a Nagini Python file.
 
@@ -76,15 +75,13 @@ async def verify_file(path: str, method: Optional[str] = None,
     e.g. `["--timeout=60"]` for a per-run verification timeout in seconds (the
     CLI's `--viper-arg`, as a list). `include_viper` returns the translated
     Viper program in `viperProgram`; even a small file translates to hundreds
-    of lines, so only request it when needed. Set `arp` to verify under
-    abstract read permissions (requires the ARP plugin on the classpath; such
-    requests run serially).
+    of lines, so only request it when needed.
     """
     selected = {method} if method else None
     result = await _run(lambda: _service.verify(
         path, selected=selected, counterexample=counterexample, base_dir=base_dir,
         ignore_global=ignore_global, viper_args=viper_args,
-        include_viper=include_viper, arp=arp, job_token=job_token))
+        include_viper=include_viper, job_token=job_token))
     return result.to_dict()
 
 
@@ -93,7 +90,6 @@ async def verify_method(path: str, method: str, counterexample: bool = False,
                         base_dir: Optional[str] = None,
                         viper_args: Optional[List[str]] = None,
                         include_viper: bool = False,
-                        arp: bool = False,
                         job_token: Optional[str] = None) -> dict:
     """Verify only a single method of a file (fast, via Nagini's --select).
 
@@ -105,7 +101,7 @@ async def verify_method(path: str, method: str, counterexample: bool = False,
     result = await _run(lambda: _service.verify(
         path, selected={method}, counterexample=counterexample,
         base_dir=base_dir, viper_args=viper_args,
-        include_viper=include_viper, arp=arp, job_token=job_token))
+        include_viper=include_viper, job_token=job_token))
     return result.to_dict()
 
 
@@ -114,7 +110,6 @@ async def verify_snippet(code: str, counterexample: bool = False,
                          ignore_global: bool = False,
                          viper_args: Optional[List[str]] = None,
                          include_viper: bool = False,
-                         arp: bool = False,
                          job_token: Optional[str] = None) -> dict:
     """Verify an inline snippet of Nagini Python code (written to a temp file).
 
@@ -129,7 +124,7 @@ async def verify_snippet(code: str, counterexample: bool = False,
         result = await _run(lambda: _service.verify(
             tmp_path, counterexample=counterexample, base_dir=tmp_dir,
             ignore_global=ignore_global, viper_args=viper_args,
-            include_viper=include_viper, arp=arp, job_token=job_token))
+            include_viper=include_viper, job_token=job_token))
         return result.to_dict()
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/src/nagini_translation/service.py
+++ b/src/nagini_translation/service.py
@@ -197,8 +197,7 @@ class VerificationService:
         to skip verification of top-level (module-global) statements.
         ``viper_args`` are extra command-line arguments for the Viper backend
         (the CLI's ``--viper-arg``, as a list). ``include_viper`` returns the
-        translated Viper program in ``viper_program``. ``arp`` verifies under
-        abstract read permissions (such requests run serially).
+        translated Viper program in ``viper_program``.
         """
         path = os.path.abspath(path)
         viper_args = list(viper_args) if viper_args else []

--- a/src/nagini_translation/service.py
+++ b/src/nagini_translation/service.py
@@ -182,7 +182,8 @@ class VerificationService:
 
     def verify(self, path: str, *, selected: Set[str] = None, base_dir: str = None,
                arp: bool = False, counterexample: bool = False,
-               ignore_global: bool = False,
+               ignore_global: bool = False, viper_args: List[str] = None,
+               obligations: str = None, write_viper_to_file: str = None,
                job_token: str = None) -> VerifyResult:
         """Translate and verify the file at ``path`` and return structured results.
 
@@ -190,22 +191,44 @@ class VerificationService:
         Viper verification overlaps. Pass a ``job_token`` to allow precise
         cancellation of this request via :meth:`cancel`. Set ``ignore_global``
         to skip verification of top-level (module-global) statements.
+        ``viper_args`` are extra command-line arguments for the Viper backend
+        (the CLI's ``--viper-arg``, as a list). ``obligations`` overrides the
+        obligation encoding for this request: ``'force'`` enables it,
+        ``'ignore'`` disables it, ``'auto'``/``None`` auto-detects per program.
+        ``write_viper_to_file`` writes the translated Viper program to that
+        path. ``arp`` verifies under abstract read permissions (such requests
+        run serially).
         """
         path = os.path.abspath(path)
+        if obligations not in (None, 'auto', 'force', 'ignore'):
+            raise ValueError("obligations must be 'auto', 'force' or 'ignore', "
+                             "got {!r}.".format(obligations))
+        viper_args = list(viper_args) if viper_args else []
         if self._can_run_concurrently(arp):
             return self._verify_concurrent(path, selected, base_dir, counterexample,
-                                           ignore_global, job_token)
+                                           ignore_global, viper_args, obligations,
+                                           write_viper_to_file, job_token)
         with self._state_lock:
             return self._verify_serial(path, selected, base_dir, arp, counterexample,
-                                       ignore_global)
+                                       ignore_global, viper_args, obligations,
+                                       write_viper_to_file)
 
-    def _reset_obligations(self) -> None:
-        """Restore the obligation auto-detection setting before a translation.
+    def _apply_obligations(self, obligations: str = None) -> None:
+        """Set the obligation encoding mode before a translation.
 
-        Must be called while holding the state lock. Setting ``disable_all`` to
-        ``None`` would be written as the string ``"None"`` (breaking getboolean),
-        so we remove the key to return to auto-detection instead.
+        Must be called while holding the state lock. ``'force'`` enables the
+        encoding and ``'ignore'`` disables it, for this translation only;
+        otherwise the service's startup setting is restored. Setting
+        ``disable_all`` to ``None`` would be written as the string ``"None"``
+        (breaking getboolean), so we remove the key to return to auto-detection
+        instead.
         """
+        if obligations == 'force':
+            config.obligation_config.disable_all = False
+            return
+        if obligations == 'ignore':
+            config.obligation_config.disable_all = True
+            return
         section = config.obligation_config._info
         if self._initial_obligations_disable_all is None:
             if 'disable_all' in section:
@@ -324,7 +347,8 @@ class VerificationService:
     # -- internals ----------------------------------------------------------
 
     def _verify_concurrent(self, path, selected, base_dir, counterexample,
-                           ignore_global, job_token) -> VerifyResult:
+                           ignore_global, viper_args, obligations,
+                           write_viper_to_file, job_token) -> VerifyResult:
         from nagini_translation.viper_server import (build_carbon_backend_args,
                                                      build_silicon_backend_args,
                                                      get_viper_server_manager)
@@ -332,7 +356,7 @@ class VerificationService:
         start = time.time()
         # 1. Translate and snapshot this job's error-mapping state (serialized).
         with self._state_lock:
-            self._reset_obligations()
+            self._apply_obligations(obligations)
             try:
                 translated = translate(
                     path, self.jvm, self._bv_size,
@@ -352,17 +376,29 @@ class VerificationService:
                     path, 'Type checking failed.', 'type.error')],
                     time.time() - start, translation_failed=True)
             modules, prog = translated
+            if write_viper_to_file:
+                with open(write_viper_to_file, 'w') as f:
+                    f.write(str(prog))
             snapshot = (dict(error_manager._items),
                         dict(error_manager._conversion_rules))
             error_manager.clear()
 
         # 2. Submit and await the result lock-free, so jobs overlap in Viper.
         if self._backend == 'carbon':
-            backend_args = build_carbon_backend_args([])
+            backend_args = build_carbon_backend_args(viper_args)
         else:
             backend_args = build_silicon_backend_args(
-                [], counterexample, self._disable_branch_conditions)
-        job_id = manager.submit(prog, path, backend_args, backend=self._backend)
+                viper_args, counterexample, self._disable_branch_conditions)
+        try:
+            job_id = manager.submit(prog, path, backend_args, backend=self._backend)
+        except Exception:
+            # Most commonly the backend rejected the arguments (Scallop parse
+            # error on a bad viper_args entry).
+            logging.exception('Verification job could not be submitted.')
+            return VerifyResult(False, [self._point_diagnostic(
+                path, 'Verification could not be started; the Viper backend '
+                'rejected the configuration (check viper_args).',
+                'verifier.error')], time.time() - start)
         if job_token is not None:
             with self._jobs_lock:
                 self._jobs[job_token] = job_id
@@ -404,10 +440,11 @@ class VerificationService:
         return VerifyResult(False, diagnostics, duration)
 
     def _verify_serial(self, path, selected, base_dir, arp,
-                       counterexample, ignore_global) -> VerifyResult:
+                       counterexample, ignore_global, viper_args, obligations,
+                       write_viper_to_file) -> VerifyResult:
         start = time.time()
         try:
-            self._reset_obligations()
+            self._apply_obligations(obligations)
             selected_set = set(selected) if selected else set()
             translated = translate(
                 path, self.jvm, self._bv_size, selected=selected_set,
@@ -419,11 +456,14 @@ class VerificationService:
                     path, 'Type checking failed.', 'type.error')],
                     time.time() - start, translation_failed=True)
             modules, prog = translated
+            if write_viper_to_file:
+                with open(write_viper_to_file, 'w') as f:
+                    f.write(str(prog))
             backend = (ViperVerifier.silicon if self._backend == 'silicon'
                        else ViperVerifier.carbon)
             vresult = verify_program(
-                modules, prog, path, self.jvm, [], backend=backend, arp=arp,
-                counterexample=counterexample, sif=self._sif,
+                modules, prog, path, self.jvm, viper_args, backend=backend,
+                arp=arp, counterexample=counterexample, sif=self._sif,
                 disable_branch_conditions=self._disable_branch_conditions)
             duration = time.time() - start
             if vresult is None:

--- a/src/nagini_translation/service.py
+++ b/src/nagini_translation/service.py
@@ -95,15 +95,19 @@ class VerifyResult:
     duration: float
     translation_failed: bool = False
     cancelled: bool = False
+    viper_program: Optional[str] = None
 
     def to_dict(self) -> dict:
-        return {
+        result = {
             'success': self.success,
             'translationFailed': self.translation_failed,
             'cancelled': self.cancelled,
             'duration': self.duration,
             'diagnostics': [d.to_dict() for d in self.diagnostics],
         }
+        if self.viper_program is not None:
+            result['viperProgram'] = self.viper_program
+        return result
 
 
 class VerificationService:
@@ -183,7 +187,7 @@ class VerificationService:
     def verify(self, path: str, *, selected: Set[str] = None, base_dir: str = None,
                arp: bool = False, counterexample: bool = False,
                ignore_global: bool = False, viper_args: List[str] = None,
-               obligations: str = None, write_viper_to_file: str = None,
+               include_viper: bool = False,
                job_token: str = None) -> VerifyResult:
         """Translate and verify the file at ``path`` and return structured results.
 
@@ -192,43 +196,27 @@ class VerificationService:
         cancellation of this request via :meth:`cancel`. Set ``ignore_global``
         to skip verification of top-level (module-global) statements.
         ``viper_args`` are extra command-line arguments for the Viper backend
-        (the CLI's ``--viper-arg``, as a list). ``obligations`` overrides the
-        obligation encoding for this request: ``'force'`` enables it,
-        ``'ignore'`` disables it, ``'auto'``/``None`` auto-detects per program.
-        ``write_viper_to_file`` writes the translated Viper program to that
-        path. ``arp`` verifies under abstract read permissions (such requests
-        run serially).
+        (the CLI's ``--viper-arg``, as a list). ``include_viper`` returns the
+        translated Viper program in ``viper_program``. ``arp`` verifies under
+        abstract read permissions (such requests run serially).
         """
         path = os.path.abspath(path)
-        if obligations not in (None, 'auto', 'force', 'ignore'):
-            raise ValueError("obligations must be 'auto', 'force' or 'ignore', "
-                             "got {!r}.".format(obligations))
         viper_args = list(viper_args) if viper_args else []
         if self._can_run_concurrently(arp):
             return self._verify_concurrent(path, selected, base_dir, counterexample,
-                                           ignore_global, viper_args, obligations,
-                                           write_viper_to_file, job_token)
+                                           ignore_global, viper_args,
+                                           include_viper, job_token)
         with self._state_lock:
             return self._verify_serial(path, selected, base_dir, arp, counterexample,
-                                       ignore_global, viper_args, obligations,
-                                       write_viper_to_file)
+                                       ignore_global, viper_args, include_viper)
 
-    def _apply_obligations(self, obligations: str = None) -> None:
-        """Set the obligation encoding mode before a translation.
+    def _reset_obligations(self) -> None:
+        """Restore the obligation auto-detection setting before a translation.
 
-        Must be called while holding the state lock. ``'force'`` enables the
-        encoding and ``'ignore'`` disables it, for this translation only;
-        otherwise the service's startup setting is restored. Setting
-        ``disable_all`` to ``None`` would be written as the string ``"None"``
-        (breaking getboolean), so we remove the key to return to auto-detection
-        instead.
+        Must be called while holding the state lock. Setting ``disable_all`` to
+        ``None`` would be written as the string ``"None"`` (breaking getboolean),
+        so we remove the key to return to auto-detection instead.
         """
-        if obligations == 'force':
-            config.obligation_config.disable_all = False
-            return
-        if obligations == 'ignore':
-            config.obligation_config.disable_all = True
-            return
         section = config.obligation_config._info
         if self._initial_obligations_disable_all is None:
             if 'disable_all' in section:
@@ -347,8 +335,8 @@ class VerificationService:
     # -- internals ----------------------------------------------------------
 
     def _verify_concurrent(self, path, selected, base_dir, counterexample,
-                           ignore_global, viper_args, obligations,
-                           write_viper_to_file, job_token) -> VerifyResult:
+                           ignore_global, viper_args, include_viper,
+                           job_token) -> VerifyResult:
         from nagini_translation.viper_server import (build_carbon_backend_args,
                                                      build_silicon_backend_args,
                                                      get_viper_server_manager)
@@ -356,7 +344,7 @@ class VerificationService:
         start = time.time()
         # 1. Translate and snapshot this job's error-mapping state (serialized).
         with self._state_lock:
-            self._apply_obligations(obligations)
+            self._reset_obligations()
             try:
                 translated = translate(
                     path, self.jvm, self._bv_size,
@@ -376,9 +364,7 @@ class VerificationService:
                     path, 'Type checking failed.', 'type.error')],
                     time.time() - start, translation_failed=True)
             modules, prog = translated
-            if write_viper_to_file:
-                with open(write_viper_to_file, 'w') as f:
-                    f.write(str(prog))
+            viper_text = str(prog) if include_viper else None
             snapshot = (dict(error_manager._items),
                         dict(error_manager._conversion_rules))
             error_manager.clear()
@@ -398,7 +384,8 @@ class VerificationService:
             return VerifyResult(False, [self._point_diagnostic(
                 path, 'Verification could not be started; the Viper backend '
                 'rejected the configuration (check viper_args).',
-                'verifier.error')], time.time() - start)
+                'verifier.error')], time.time() - start,
+                viper_program=viper_text)
         if job_token is not None:
             with self._jobs_lock:
                 self._jobs[job_token] = job_id
@@ -407,7 +394,8 @@ class VerificationService:
         except Exception:
             # Most commonly this is a cancelled job (its actor was stopped).
             logging.debug('Verification job failed or was cancelled.', exc_info=True)
-            return VerifyResult(False, [], time.time() - start, cancelled=True)
+            return VerifyResult(False, [], time.time() - start, cancelled=True,
+                                viper_program=viper_text)
         finally:
             if job_token is not None:
                 with self._jobs_lock:
@@ -420,12 +408,12 @@ class VerificationService:
         if result is None:
             return VerifyResult(False, [self._point_diagnostic(
                 path, 'Internal verifier error (see server log).',
-                'verifier.error')], duration)
+                'verifier.error')], duration, viper_program=viper_text)
 
         # 3. Convert the result with this job's snapshot installed (serialized).
         is_failure = isinstance(result, self.jvm.viper.silver.verifier.Failure)
         if not is_failure:
-            return VerifyResult(True, [], duration)
+            return VerifyResult(True, [], duration, viper_program=viper_text)
         with self._state_lock:
             error_manager._items, error_manager._conversion_rules = snapshot
             try:
@@ -437,14 +425,14 @@ class VerificationService:
                 diagnostics = self._failure_diagnostics(failure, path)
             finally:
                 error_manager.clear()
-        return VerifyResult(False, diagnostics, duration)
+        return VerifyResult(False, diagnostics, duration, viper_program=viper_text)
 
     def _verify_serial(self, path, selected, base_dir, arp,
-                       counterexample, ignore_global, viper_args, obligations,
-                       write_viper_to_file) -> VerifyResult:
+                       counterexample, ignore_global, viper_args,
+                       include_viper) -> VerifyResult:
         start = time.time()
         try:
-            self._apply_obligations(obligations)
+            self._reset_obligations()
             selected_set = set(selected) if selected else set()
             translated = translate(
                 path, self.jvm, self._bv_size, selected=selected_set,
@@ -456,9 +444,7 @@ class VerificationService:
                     path, 'Type checking failed.', 'type.error')],
                     time.time() - start, translation_failed=True)
             modules, prog = translated
-            if write_viper_to_file:
-                with open(write_viper_to_file, 'w') as f:
-                    f.write(str(prog))
+            viper_text = str(prog) if include_viper else None
             backend = (ViperVerifier.silicon if self._backend == 'silicon'
                        else ViperVerifier.carbon)
             vresult = verify_program(
@@ -470,11 +456,11 @@ class VerificationService:
                 # main.verify swallows JVM exceptions and returns None.
                 return VerifyResult(False, [self._point_diagnostic(
                     path, 'Internal verifier error (see server log).',
-                    'verifier.error')], duration)
+                    'verifier.error')], duration, viper_program=viper_text)
             if isinstance(vresult, Failure):
                 return VerifyResult(False, self._failure_diagnostics(vresult, path),
-                                    duration)
-            return VerifyResult(True, [], duration)
+                                    duration, viper_program=viper_text)
+            return VerifyResult(True, [], duration, viper_program=viper_text)
         except (TypeException, InvalidProgramException, UnsupportedException) as e:
             return VerifyResult(False, self._exception_diagnostics(e, path),
                                 time.time() - start, translation_failed=True)

--- a/src/nagini_translation/service.py
+++ b/src/nagini_translation/service.py
@@ -374,17 +374,7 @@ class VerificationService:
         else:
             backend_args = build_silicon_backend_args(
                 viper_args, counterexample, self._disable_branch_conditions)
-        try:
-            job_id = manager.submit(prog, path, backend_args, backend=self._backend)
-        except Exception:
-            # Most commonly the backend rejected the arguments (Scallop parse
-            # error on a bad viper_args entry).
-            logging.exception('Verification job could not be submitted.')
-            return VerifyResult(False, [self._point_diagnostic(
-                path, 'Verification could not be started; the Viper backend '
-                'rejected the configuration (check viper_args).',
-                'verifier.error')], time.time() - start,
-                viper_program=viper_text)
+        job_id = manager.submit(prog, path, backend_args, backend=self._backend)
         if job_token is not None:
             with self._jobs_lock:
                 self._jobs[job_token] = job_id

--- a/tests/servers/test_mcp_server.py
+++ b/tests/servers/test_mcp_server.py
@@ -213,28 +213,14 @@ def test_verify_ignore_global_via_tool(service):
         mcp_server.verify_snippet(_TOPLEVEL_ASSERT_SRC, ignore_global=True))["success"] is True
 
 
-_MUST_TERMINATE_BAD_SRC = (
-    "from nagini_contracts.contracts import *\n"
-    "from nagini_contracts.obligations import MustTerminate\n\n"
-    "def rec(n: int) -> int:\n    Requires(MustTerminate(1))\n    return rec(n)\n"
-)
-
-
-def test_verify_viper_args_and_write_viper_via_tool(service, tmp_path, pass_src):
+def test_verify_viper_args_and_include_viper_via_tool(service, pass_src):
     mcp_server._service = service
-    out = tmp_path / "snippet.vpr"
     result = asyncio.run(mcp_server.verify_snippet(
-        pass_src, viper_args=["--timeout=300"], write_viper_to_file=str(out)))
+        pass_src, viper_args=["--timeout=300"], include_viper=True))
     assert result["success"] is True
-    assert "method" in out.read_text()
-
-
-def test_verify_obligations_override_via_tool(service):
-    mcp_server._service = service
-    assert asyncio.run(mcp_server.verify_snippet(
-        _MUST_TERMINATE_BAD_SRC, obligations="ignore"))["success"] is True
-    assert asyncio.run(mcp_server.verify_snippet(
-        _MUST_TERMINATE_BAD_SRC))["success"] is False
+    assert "method" in result["viperProgram"]
+    # The (large) Viper program is only included on request.
+    assert "viperProgram" not in asyncio.run(mcp_server.verify_snippet(pass_src))
 
 
 def test_configure_disable_branch_conditions_via_tool(service):

--- a/tests/servers/test_mcp_server.py
+++ b/tests/servers/test_mcp_server.py
@@ -213,6 +213,30 @@ def test_verify_ignore_global_via_tool(service):
         mcp_server.verify_snippet(_TOPLEVEL_ASSERT_SRC, ignore_global=True))["success"] is True
 
 
+_MUST_TERMINATE_BAD_SRC = (
+    "from nagini_contracts.contracts import *\n"
+    "from nagini_contracts.obligations import MustTerminate\n\n"
+    "def rec(n: int) -> int:\n    Requires(MustTerminate(1))\n    return rec(n)\n"
+)
+
+
+def test_verify_viper_args_and_write_viper_via_tool(service, tmp_path, pass_src):
+    mcp_server._service = service
+    out = tmp_path / "snippet.vpr"
+    result = asyncio.run(mcp_server.verify_snippet(
+        pass_src, viper_args=["--timeout=300"], write_viper_to_file=str(out)))
+    assert result["success"] is True
+    assert "method" in out.read_text()
+
+
+def test_verify_obligations_override_via_tool(service):
+    mcp_server._service = service
+    assert asyncio.run(mcp_server.verify_snippet(
+        _MUST_TERMINATE_BAD_SRC, obligations="ignore"))["success"] is True
+    assert asyncio.run(mcp_server.verify_snippet(
+        _MUST_TERMINATE_BAD_SRC))["success"] is False
+
+
 def test_configure_disable_branch_conditions_via_tool(service):
     mcp_server._service = service
     original = service.current_options()

--- a/tests/servers/test_verification_options.py
+++ b/tests/servers/test_verification_options.py
@@ -7,7 +7,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
 """Service-level tests for verification options: --ignore-global,
---disable-branch-conditions, and obligation auto-detection."""
+--disable-branch-conditions, obligation auto-detection and per-request
+overrides, per-request Viper backend arguments, and --write-viper-to-file."""
+
+
+import pytest
 
 
 _TOPLEVEL_ASSERT_SRC = (
@@ -107,3 +111,67 @@ def test_obligations_autodetected_per_program(service, tmp_path):
         _write(tmp_path, "must_terminate_bad.py", _MUST_TERMINATE_BAD_SRC))
     assert not bad.success
     assert bad.diagnostics
+
+
+# -- per-request obligation overrides ----------------------------------------
+
+def test_obligations_ignore_disables_encoding_per_request(service, tmp_path):
+    # With the encoding disabled for this request, the unsatisfiable
+    # MustTerminate obligation is not checked and the program verifies.
+    assert service.verify(
+        _write(tmp_path, "mt_bad_ignored.py", _MUST_TERMINATE_BAD_SRC),
+        obligations="ignore").success
+    # The override is per-request: the next auto-detected run checks it again.
+    assert not service.verify(
+        _write(tmp_path, "mt_bad_auto.py", _MUST_TERMINATE_BAD_SRC)).success
+
+
+def test_obligations_force_keeps_encoding_active(service, tmp_path):
+    assert service.verify(
+        _write(tmp_path, "no_obl_forced.py", _NO_OBLIGATIONS_SRC),
+        obligations="force").success
+
+
+def test_obligations_invalid_value_rejected(service, tmp_path):
+    with pytest.raises(ValueError):
+        service.verify(_write(tmp_path, "obl_bad.py", _NO_OBLIGATIONS_SRC),
+                       obligations="never")
+
+
+# -- per-request viper args ---------------------------------------------------
+
+def test_viper_args_reach_the_backend_command_line(service, tmp_path):
+    original = service.current_options()
+    try:
+        service.reconfigure(disable_branch_conditions=True)
+        # Baseline: the service-wide option suppresses branch conditions.
+        off = service.verify(_write(tmp_path, "va_off.py", _BRANCH_ERROR_SRC))
+        assert not off.success
+        assert all(not d.branch_conditions for d in off.diagnostics)
+        # Re-enabling the flag through per-request viper_args overrides it,
+        # which proves the arguments end up on the backend command line.
+        on = service.verify(
+            _write(tmp_path, "va_on.py", _BRANCH_ERROR_SRC),
+            viper_args=["--enableBranchconditionReporting"])
+        assert not on.success
+        assert any(d.branch_conditions for d in on.diagnostics)
+    finally:
+        service.reconfigure(
+            disable_branch_conditions=original["disableBranchConditions"])
+
+
+def test_viper_args_invalid_option_fails_cleanly(service, tmp_path):
+    result = service.verify(
+        _write(tmp_path, "va_bad.py", _NO_OBLIGATIONS_SRC),
+        viper_args=["--no-such-silicon-option"])
+    assert not result.success
+
+
+# -- --write-viper-to-file ----------------------------------------------------
+
+def test_write_viper_to_file(service, tmp_path):
+    out = tmp_path / "translated.vpr"
+    assert service.verify(
+        _write(tmp_path, "wv.py", _NO_OBLIGATIONS_SRC),
+        write_viper_to_file=str(out)).success
+    assert "method" in out.read_text()

--- a/tests/servers/test_verification_options.py
+++ b/tests/servers/test_verification_options.py
@@ -7,11 +7,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
 """Service-level tests for verification options: --ignore-global,
---disable-branch-conditions, obligation auto-detection and per-request
-overrides, per-request Viper backend arguments, and --write-viper-to-file."""
-
-
-import pytest
+--disable-branch-conditions, obligation auto-detection, per-request Viper
+backend arguments, and include_viper."""
 
 
 _TOPLEVEL_ASSERT_SRC = (
@@ -113,31 +110,6 @@ def test_obligations_autodetected_per_program(service, tmp_path):
     assert bad.diagnostics
 
 
-# -- per-request obligation overrides ----------------------------------------
-
-def test_obligations_ignore_disables_encoding_per_request(service, tmp_path):
-    # With the encoding disabled for this request, the unsatisfiable
-    # MustTerminate obligation is not checked and the program verifies.
-    assert service.verify(
-        _write(tmp_path, "mt_bad_ignored.py", _MUST_TERMINATE_BAD_SRC),
-        obligations="ignore").success
-    # The override is per-request: the next auto-detected run checks it again.
-    assert not service.verify(
-        _write(tmp_path, "mt_bad_auto.py", _MUST_TERMINATE_BAD_SRC)).success
-
-
-def test_obligations_force_keeps_encoding_active(service, tmp_path):
-    assert service.verify(
-        _write(tmp_path, "no_obl_forced.py", _NO_OBLIGATIONS_SRC),
-        obligations="force").success
-
-
-def test_obligations_invalid_value_rejected(service, tmp_path):
-    with pytest.raises(ValueError):
-        service.verify(_write(tmp_path, "obl_bad.py", _NO_OBLIGATIONS_SRC),
-                       obligations="never")
-
-
 # -- per-request viper args ---------------------------------------------------
 
 def test_viper_args_reach_the_backend_command_line(service, tmp_path):
@@ -167,11 +139,14 @@ def test_viper_args_invalid_option_fails_cleanly(service, tmp_path):
     assert not result.success
 
 
-# -- --write-viper-to-file ----------------------------------------------------
+# -- include_viper ------------------------------------------------------------
 
-def test_write_viper_to_file(service, tmp_path):
-    out = tmp_path / "translated.vpr"
-    assert service.verify(
-        _write(tmp_path, "wv.py", _NO_OBLIGATIONS_SRC),
-        write_viper_to_file=str(out)).success
-    assert "method" in out.read_text()
+def test_include_viper_returns_translated_program(service, tmp_path):
+    result = service.verify(_write(tmp_path, "iv.py", _NO_OBLIGATIONS_SRC),
+                            include_viper=True)
+    assert result.success
+    assert "method" in result.viper_program
+    # Off by default, and then absent from the serialized result.
+    default = service.verify(_write(tmp_path, "iv2.py", _NO_OBLIGATIONS_SRC))
+    assert default.viper_program is None
+    assert "viperProgram" not in default.to_dict()


### PR DESCRIPTION
Exposes the cli flag --viper-args in mcp mode. Also allows requesting the generated viper translation as part of the response.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/309)
<!-- Reviewable:end -->
