### PR TITLE
Fixing translation of quantifiers over containers

### DIFF
--- a/src/nagini_translation/translators/contract.py
+++ b/src/nagini_translation/translators/contract.py
@@ -673,7 +673,9 @@ class ContractTranslator(CommonTranslator):
 
         dom_target = self.get_target(domain_node, ctx)
 
-        if isinstance(dom_target, PythonType):
+        if isinstance(dom_target, PythonType) and not isinstance(domain_node, ast.Call):
+            # We were given a type, not a container; the check for ast.Call is needed because
+            # get_target also returns a PythonType for constructor calls.
             result = self.type_check(ref_var, dom_target, pos, ctx, False)
             # Not recommended as a trigger, since it's very broad and will get triggered
             # a lot.

--- a/tests/functional/verification/test_forall.py
+++ b/tests/functional/verification/test_forall.py
@@ -88,6 +88,12 @@ def test_type_quantification_n_fail(d: Dict[str, str], s: str) -> None:
     Assert(Forall2(int, int, lambda i, j: (Implies(i >= 0 and i < len(r) and j >= 0 and j < 3, r[i][j] > 3), [[r[i][j]]])))
 
 
+def range_quant_fail(xs: List[int]) -> None:
+    Requires(Acc(list_pred(xs)))
+    #:: ExpectedOutput(assert.failed:assertion.false)
+    Assert(Forall(range(0, len(xs)), lambda i: (xs[i] == 8, [[xs[i]]])))
+
+
 def foo(l: Optional[List[int]]) -> None:
     Requires(l is not None)
     Requires(list_pred(l))


### PR DESCRIPTION
Quantification over containers is currently mistranslated when the container expression is a constructor call. As a result, the following program verifies incorrectly (found by @rayman2000):

```
def range_quant_fail(xs: List[int]) -> None:
    Requires(Acc(list_pred(xs)))
    Assert(Forall(range(0, len(xs)), lambda i: (xs[i] == 8, [[xs[i]]])))
```

This PR fixes the mistranslation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marcoeilers/nagini/315)
<!-- Reviewable:end -->
